### PR TITLE
Fix client dashboard edit pages to read params synchronously

### DIFF
--- a/app/dashboard/career/[id]/page.tsx
+++ b/app/dashboard/career/[id]/page.tsx
@@ -17,9 +17,9 @@ import { DashboardHeader } from "@/components/dashboard-header"
 import { FileUpload } from "@/components/file-upload"
 
 interface EditCareerPageProps {
-  params: Promise<{
-    id: string
-  }>
+  params: {
+    id?: string
+  }
 }
 
 interface CareerEntry {
@@ -55,44 +55,18 @@ export default function EditCareerPage({ params }: EditCareerPageProps) {
   const [careerId, setCareerId] = useState<string | null>(null)
 
   useEffect(() => {
-    let isMounted = true
-
-    params
-      .then((value) => {
-        if (!isMounted) {
-          return
-        }
-
-        if (!value?.id) {
-          console.error("Missing career id in route params")
-          toast({
-            title: "Invalid route",
-            description: "The career entry identifier is missing from the URL.",
-            variant: "destructive",
-          })
-          setIsLoading(false)
-          return
-        }
-
-        setCareerId(value.id)
+    if (!params?.id) {
+      console.error("Missing career id in route params")
+      toast({
+        title: "Invalid route",
+        description: "The career entry identifier is missing from the URL.",
+        variant: "destructive",
       })
-      .catch((error) => {
-        if (!isMounted) {
-          return
-        }
-
-        console.error("Failed to resolve career route params:", error)
-        toast({
-          title: "Invalid route",
-          description: "We were unable to read the career entry identifier from the URL.",
-          variant: "destructive",
-        })
-        setIsLoading(false)
-      })
-
-    return () => {
-      isMounted = false
+      setIsLoading(false)
+      return
     }
+
+    setCareerId(params.id)
   }, [params, toast])
 
   useEffect(() => {

--- a/app/dashboard/certificates/[id]/page.tsx
+++ b/app/dashboard/certificates/[id]/page.tsx
@@ -17,9 +17,9 @@ import { FileUpload } from "@/components/file-upload"
 import type { Certificate } from "@/types/database"
 
 interface EditCertificatePageProps {
-  params: Promise<{
-    id: string
-  }>
+  params: {
+    id?: string
+  }
 }
 
 export default function EditCertificatePage({ params }: EditCertificatePageProps) {
@@ -32,44 +32,18 @@ export default function EditCertificatePage({ params }: EditCertificatePageProps
   const [certificateId, setCertificateId] = useState<string | null>(null)
 
   useEffect(() => {
-    let isMounted = true
-
-    params
-      .then((value) => {
-        if (!isMounted) {
-          return
-        }
-
-        if (!value?.id) {
-          console.error("Missing certificate id in route params")
-          toast({
-            title: "Invalid route",
-            description: "The certificate identifier is missing from the URL.",
-            variant: "destructive",
-          })
-          setIsLoading(false)
-          return
-        }
-
-        setCertificateId(value.id)
+    if (!params?.id) {
+      console.error("Missing certificate id in route params")
+      toast({
+        title: "Invalid route",
+        description: "The certificate identifier is missing from the URL.",
+        variant: "destructive",
       })
-      .catch((error) => {
-        if (!isMounted) {
-          return
-        }
-
-        console.error("Failed to resolve certificate route params:", error)
-        toast({
-          title: "Invalid route",
-          description: "We were unable to read the certificate identifier from the URL.",
-          variant: "destructive",
-        })
-        setIsLoading(false)
-      })
-
-    return () => {
-      isMounted = false
+      setIsLoading(false)
+      return
     }
+
+    setCertificateId(params.id)
   }, [params, toast])
 
   useEffect(() => {

--- a/app/dashboard/contacts/[id]/page.tsx
+++ b/app/dashboard/contacts/[id]/page.tsx
@@ -27,9 +27,9 @@ interface Contact {
 }
 
 interface ContactDetailsPageProps {
-    params: Promise<{
-        id: string
-    }>
+    params: {
+        id?: string
+    }
 }
 
 export default function ContactDetailsPage({ params }: ContactDetailsPageProps) {
@@ -42,44 +42,18 @@ export default function ContactDetailsPage({ params }: ContactDetailsPageProps) 
     const [contactId, setContactId] = useState<string | null>(null)
 
     useEffect(() => {
-        let isMounted = true
-
-        params
-            .then((value) => {
-                if (!isMounted) {
-                    return
-                }
-
-                if (!value?.id) {
-                    console.error("Missing contact id in route params")
-                    toast({
-                        title: "Invalid route",
-                        description: "The contact identifier is missing from the URL.",
-                        variant: "destructive",
-                    })
-                    setLoading(false)
-                    return
-                }
-
-                setContactId(value.id)
+        if (!params?.id) {
+            console.error("Missing contact id in route params")
+            toast({
+                title: "Invalid route",
+                description: "The contact identifier is missing from the URL.",
+                variant: "destructive",
             })
-            .catch((error) => {
-                if (!isMounted) {
-                    return
-                }
-
-                console.error("Failed to resolve contact route params:", error)
-                toast({
-                    title: "Invalid route",
-                    description: "We were unable to read the contact identifier from the URL.",
-                    variant: "destructive",
-                })
-                setLoading(false)
-            })
-
-        return () => {
-            isMounted = false
+            setLoading(false)
+            return
         }
+
+        setContactId(params.id)
     }, [params, toast])
 
     const handleStatusChange = useCallback(

--- a/app/dashboard/projects/[id]/page.tsx
+++ b/app/dashboard/projects/[id]/page.tsx
@@ -20,9 +20,9 @@ import type { FeatureDraft } from "@/components/feature-input"
 import type { Project } from "@/types/database"
 
 interface EditProjectPageProps {
-  params: Promise<{
-    id: string
-  }>
+  params: {
+    id?: string
+  }
 }
 
 export default function EditProjectPage({ params }: EditProjectPageProps) {
@@ -40,44 +40,18 @@ export default function EditProjectPage({ params }: EditProjectPageProps) {
   const [projectId, setProjectId] = useState<string | null>(null)
 
   useEffect(() => {
-    let isMounted = true
-
-    params
-      .then((value) => {
-        if (!isMounted) {
-          return
-        }
-
-        if (!value?.id) {
-          console.error("Missing project id in route params")
-          toast({
-            title: "Invalid route",
-            description: "The project identifier is missing from the URL.",
-            variant: "destructive",
-          })
-          setIsLoading(false)
-          return
-        }
-
-        setProjectId(value.id)
+    if (!params?.id) {
+      console.error("Missing project id in route params")
+      toast({
+        title: "Invalid route",
+        description: "The project identifier is missing from the URL.",
+        variant: "destructive",
       })
-      .catch((error) => {
-        if (!isMounted) {
-          return
-        }
-
-        console.error("Failed to resolve project route params:", error)
-        toast({
-          title: "Invalid route",
-          description: "We were unable to read the project identifier from the URL.",
-          variant: "destructive",
-        })
-        setIsLoading(false)
-      })
-
-    return () => {
-      isMounted = false
+      setIsLoading(false)
+      return
     }
+
+    setProjectId(params.id)
   }, [params, toast])
 
   useEffect(() => {

--- a/app/dashboard/skills/[id]/page.tsx
+++ b/app/dashboard/skills/[id]/page.tsx
@@ -23,9 +23,9 @@ const iconNames = Object.keys(LucideIcons).filter(
 )
 
 interface EditSkillPageProps {
-  params: Promise<{
-    id: string
-  }>
+  params: {
+    id?: string
+  }
 }
 
 export default function EditSkillPage({ params }: EditSkillPageProps) {
@@ -43,44 +43,18 @@ export default function EditSkillPage({ params }: EditSkillPageProps) {
     : null
 
   useEffect(() => {
-    let isMounted = true
-
-    params
-      .then((value) => {
-        if (!isMounted) {
-          return
-        }
-
-        if (!value?.id) {
-          console.error("Missing skill id in route params")
-          toast({
-            title: "Invalid route",
-            description: "The skill identifier is missing from the URL.",
-            variant: "destructive",
-          })
-          setIsLoading(false)
-          return
-        }
-
-        setSkillId(value.id)
+    if (!params?.id) {
+      console.error("Missing skill id in route params")
+      toast({
+        title: "Invalid route",
+        description: "The skill identifier is missing from the URL.",
+        variant: "destructive",
       })
-      .catch((error) => {
-        if (!isMounted) {
-          return
-        }
-
-        console.error("Failed to resolve skill route params:", error)
-        toast({
-          title: "Invalid route",
-          description: "We were unable to read the skill identifier from the URL.",
-          variant: "destructive",
-        })
-        setIsLoading(false)
-      })
-
-    return () => {
-      isMounted = false
+      setIsLoading(false)
+      return
     }
+
+    setSkillId(params.id)
   }, [params, toast])
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- update dashboard edit pages to accept synchronous params objects
- restore immediate ID validation and state initialization without Promise chains
- ensure loading states clear when params are missing to avoid runtime crashes

## Testing
- pnpm lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68f7a4d921c0832cbce08d130e966617