### PR TITLE
Enable dashboard file uploads and persist media metadata

### DIFF
--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -24,6 +24,22 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "No file provided" }, { status: 400 })
     }
 
+    const allowedMimeTypes = [
+      "image/jpeg",
+      "image/png",
+      "image/gif",
+      "image/webp",
+      "image/avif",
+      "image/svg+xml",
+    ]
+
+    if (!file.type || !allowedMimeTypes.includes(file.type)) {
+      return NextResponse.json(
+        { error: "Only image uploads are allowed" },
+        { status: 415 }
+      )
+    }
+
     const maxSize = 10 * 1024 * 1024 // 10MB
     if (file.size > maxSize) {
       return NextResponse.json({ error: "File size must be less than 10MB" }, { status: 400 })

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,6 +26,7 @@ model User {
   skills        Skill[]
   careers       Career[]
   announcements AnnouncementSettings?
+  media         Media[]
 }
 
 model Project {
@@ -193,4 +194,16 @@ model AnnouncementSettings {
   newCareers      Boolean  @default(true)
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
+}
+
+model Media {
+  id           String   @id @default(cuid())
+  userId       String
+  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  originalName String
+  fileName     String
+  mimeType     String?
+  size         Int
+  url          String
+  createdAt    DateTime @default(now())
 }

--- a/types/database.ts
+++ b/types/database.ts
@@ -178,3 +178,14 @@ export interface AnnouncementSettings {
   createdAt: Date | string
   updatedAt: Date | string
 }
+
+export interface Media {
+  id: string
+  userId: string
+  originalName: string
+  fileName: string
+  mimeType: string | null
+  size: number
+  url: string
+  createdAt: Date | string
+}


### PR DESCRIPTION
## Summary
- allow the upload API to persist files on disk and create media records linked to the current user
- update the reusable file upload component to send files to the API, handle previews, and surface upload feedback
- integrate the improved uploader into the settings page so profile images are stored and synced with the account
- extend the Prisma schema and shared database types with a Media model for uploaded assets

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_69012d5deb34832ca447be97ad6f2460