### PR TITLE
Fix filename derivation in file upload component

### DIFF
--- a/components/file-upload.tsx
+++ b/components/file-upload.tsx
@@ -38,7 +38,8 @@ export function FileUpload({
     setPreview(value || null)
     if (value) {
       const segments = value.split("/")
-      setFileName((current) => current ?? segments[segments.length - 1] || null)
+      const derivedFileName = segments[segments.length - 1] ?? null
+      setFileName((current) => current ?? derivedFileName)
     } else {
       setFileName(null)
     }


### PR DESCRIPTION
## Summary
- derive the file name from upload responses without mixing nullish and boolean coalescing operators
- ensure the file upload component retains existing names when provided

## Testing
- pnpm lint
- pnpm typecheck
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_6904f1998918832cb5925a3b4986ea6f