### PR TITLE
Fix Prisma transaction typings in register route

### DIFF
--- a/app/api/register/route.ts
+++ b/app/api/register/route.ts
@@ -1,7 +1,7 @@
 import bcrypt from "bcryptjs"
 import { NextResponse } from "next/server"
 
-import { Prisma } from "@prisma/client"
+import type { PrismaClient } from "@prisma/client"
 
 import prisma from "@/lib/db"
 
@@ -44,7 +44,7 @@ export async function POST(req: Request) {
     const sanitizedName = typeof name === "string" ? name.trim() : null
 
     const user = await prisma.$transaction(
-      async (tx) => {
+      async (tx: PrismaClient) => {
         const existingUsers = await tx.user.count()
         const role = existingUsers === 0 ? "Admin" : "Member"
 
@@ -57,7 +57,7 @@ export async function POST(req: Request) {
           },
         })
       },
-      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+      { isolationLevel: "Serializable" },
     )
 
     // Return user without password


### PR DESCRIPTION
## Summary
- annotate the register transaction callback with PrismaClient to satisfy strict TS settings
- replace use of Prisma.TransactionIsolationLevel with literal string to avoid runtime value usage

## Testing
- pnpm lint
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_6905038fe944832c92e44b301588f548