### PR TITLE
Fix newsletter unsubscribe flow

### DIFF
--- a/app/api/newsletter/confirm/route.ts
+++ b/app/api/newsletter/confirm/route.ts
@@ -34,7 +34,7 @@ export async function GET(req: Request) {
     })
 
     // Send welcome email
-    await sendWelcomeEmail(subscriber.email, subscriber.name || "")
+    await sendWelcomeEmail(subscriber.email, subscriber.name || "", subscriber.token)
 
     return NextResponse.json({
       message: "Your subscription has been confirmed successfully",

--- a/app/api/newsletter/preferences/route.ts
+++ b/app/api/newsletter/preferences/route.ts
@@ -1,10 +1,139 @@
 import { NextResponse } from "next/server"
-import prisma from "@/lib/db"
+import { getServerSession } from "next-auth"
 
-// POST: Update preferences
+import prisma from "@/lib/db"
+import { authOptions } from "@/lib/auth"
+
+const DEFAULT_SUBSCRIBER_PREFERENCES = {
+  projects: true,
+  certificates: true,
+  skills: true,
+  careers: true,
+}
+
+const DEFAULT_ANNOUNCEMENT_SETTINGS = {
+  newProjects: true,
+  newCertificates: true,
+  newSkills: true,
+  newCareers: true,
+}
+
+type PreferencePayload = {
+  projects: boolean
+  certificates: boolean
+  skills: boolean
+  careers: boolean
+}
+
+function parsePreferences(preferences: unknown): PreferencePayload | null {
+  if (!preferences || typeof preferences !== "object") {
+    return null
+  }
+
+  const prefs = preferences as Record<string, unknown>
+
+  const parsed: PreferencePayload = {
+    projects: Boolean(prefs.projects),
+    certificates: Boolean(prefs.certificates),
+    skills: Boolean(prefs.skills),
+    careers: Boolean(prefs.careers),
+  }
+
+  return parsed
+}
+
+export async function GET(req: Request) {
+  try {
+    const { searchParams } = new URL(req.url)
+    const token = searchParams.get("token")
+
+    if (token) {
+      const subscriber = await prisma.subscriber.findUnique({
+        where: { token },
+        include: { preferences: true },
+      })
+
+      if (!subscriber) {
+        return NextResponse.json(DEFAULT_SUBSCRIBER_PREFERENCES)
+      }
+
+      if (!subscriber.preferences) {
+        return NextResponse.json(DEFAULT_SUBSCRIBER_PREFERENCES)
+      }
+
+      return NextResponse.json({
+        projects: subscriber.preferences.projects,
+        certificates: subscriber.preferences.certificates,
+        skills: subscriber.preferences.skills,
+        careers: subscriber.preferences.careers,
+      })
+    }
+
+    const session = await getServerSession(authOptions)
+
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const settings = await prisma.announcementSettings.findUnique({
+      where: { userId: session.user.id },
+    })
+
+    if (!settings) {
+      return NextResponse.json(DEFAULT_ANNOUNCEMENT_SETTINGS)
+    }
+
+    return NextResponse.json({
+      newProjects: settings.newProjects,
+      newCertificates: settings.newCertificates,
+      newSkills: settings.newSkills,
+      newCareers: settings.newCareers,
+    })
+  } catch (error) {
+    console.error("Fetch preferences error:", error)
+    return NextResponse.json({ error: "Failed to fetch preferences" }, { status: 500 })
+  }
+}
+
 export async function POST(req: Request) {
   try {
+    const session = await getServerSession(authOptions)
     const { token, preferences } = await req.json()
+
+    const parsedPreferences = parsePreferences(preferences)
+
+    if (!parsedPreferences) {
+      return NextResponse.json({ error: "Invalid preferences" }, { status: 400 })
+    }
+
+    if (session?.user?.id) {
+      const updatedSettings = await prisma.announcementSettings.upsert({
+        where: { userId: session.user.id },
+        create: {
+          userId: session.user.id,
+          newProjects: parsedPreferences.projects,
+          newCertificates: parsedPreferences.certificates,
+          newSkills: parsedPreferences.skills,
+          newCareers: parsedPreferences.careers,
+        },
+        update: {
+          newProjects: parsedPreferences.projects,
+          newCertificates: parsedPreferences.certificates,
+          newSkills: parsedPreferences.skills,
+          newCareers: parsedPreferences.careers,
+        },
+      })
+
+      return NextResponse.json({
+        message: "Your newsletter announcement settings have been saved.",
+        preferences: {
+          newProjects: updatedSettings.newProjects,
+          newCertificates: updatedSettings.newCertificates,
+          newSkills: updatedSettings.newSkills,
+          newCareers: updatedSettings.newCareers,
+        },
+      })
+    }
 
     if (!token) {
       return NextResponse.json({ error: "Invalid token" }, { status: 400 })
@@ -19,84 +148,29 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Invalid subscription token" }, { status: 404 })
     }
 
-    if (subscriber.preferences) {
-      await prisma.subscriberPreference.update({
-        where: { id: subscriber.preferences.id },
-        data: {
-          projects: preferences.projects,
-          certificates: preferences.certificates,
-          skills: preferences.skills,
-          careers: preferences.careers,
-        },
-      })
-    } else {
-      await prisma.subscriberPreference.create({
-        data: {
-          subscriberId: subscriber.id,
-          projects: preferences.projects,
-          certificates: preferences.certificates,
-          skills: preferences.skills,
-          careers: preferences.careers,
-        },
-      })
-    }
+    await prisma.subscriberPreference.upsert({
+      where: { subscriberId: subscriber.id },
+      create: {
+        subscriberId: subscriber.id,
+        projects: parsedPreferences.projects,
+        certificates: parsedPreferences.certificates,
+        skills: parsedPreferences.skills,
+        careers: parsedPreferences.careers,
+      },
+      update: {
+        projects: parsedPreferences.projects,
+        certificates: parsedPreferences.certificates,
+        skills: parsedPreferences.skills,
+        careers: parsedPreferences.careers,
+      },
+    })
 
     return NextResponse.json({
-      message: "Your newsletter preferences have been updated successfully",
+      message: "Your newsletter preferences have been updated successfully.",
+      preferences: parsedPreferences,
     })
   } catch (error) {
     console.error("Update preferences error:", error)
     return NextResponse.json({ error: "Failed to update preferences" }, { status: 500 })
-  }
-}
-
-export async function GET(req: Request) {
-  try {
-    const { searchParams } = new URL(req.url)
-    const token = searchParams.get("token")
-
-    if (!token) {
-      return NextResponse.json({
-        projects: true,
-        certificates: true,
-        skills: true,
-        careers: true,
-      })
-    }
-
-    const subscriber = await prisma.subscriber.findUnique({
-      where: { token },
-      include: { preferences: true },
-    })
-
-    if (!subscriber) {
-      return NextResponse.json({
-        projects: true,
-        certificates: true,
-        skills: true,
-        careers: true,
-      })
-    }
-
-    if (!subscriber.preferences) {
-      // Subscriber gefunden, aber keine gespeicherten Präferenzen → Defaults
-      return NextResponse.json({
-        projects: true,
-        certificates: true,
-        skills: true,
-        careers: true,
-      })
-    }
-
-    // Alles okay → gib gespeicherte Präferenzen zurück
-    return NextResponse.json({
-      projects: subscriber.preferences.projects,
-      certificates: subscriber.preferences.certificates,
-      skills: subscriber.preferences.skills,
-      careers: subscriber.preferences.careers,
-    })
-  } catch (error) {
-    console.error("Fetch preferences error:", error)
-    return NextResponse.json({ error: "Failed to fetch preferences" }, { status: 500 })
   }
 }

--- a/app/api/newsletter/verify/route.ts
+++ b/app/api/newsletter/verify/route.ts
@@ -1,6 +1,13 @@
 import { NextResponse } from "next/server"
 import prisma from "@/lib/db"
 
+const DEFAULT_PREFERENCES = {
+  projects: true,
+  certificates: true,
+  skills: true,
+  careers: true,
+}
+
 export async function GET(req: Request) {
   try {
     const { searchParams } = new URL(req.url)
@@ -10,7 +17,6 @@ export async function GET(req: Request) {
       return NextResponse.json({ error: "Invalid token" }, { status: 400 })
     }
 
-    // Find subscriber by token
     const subscriber = await prisma.subscriber.findUnique({
       where: { token },
       include: { preferences: true },
@@ -20,16 +26,19 @@ export async function GET(req: Request) {
       return NextResponse.json({ error: "Invalid subscription token" }, { status: 404 })
     }
 
+    const preferences = subscriber.preferences
+      ? {
+          projects: subscriber.preferences.projects,
+          certificates: subscriber.preferences.certificates,
+          skills: subscriber.preferences.skills,
+          careers: subscriber.preferences.careers,
+        }
+      : DEFAULT_PREFERENCES
+
     return NextResponse.json({
       email: subscriber.email,
-      preferences: subscriber.preferences
-        ? {
-            projects: subscriber.preferences.projects,
-            certificates: subscriber.preferences.certificates,
-            skills: subscriber.preferences.skills,
-            careers: subscriber.preferences.careers,
-          }
-        : null,
+      name: subscriber.name,
+      preferences,
     })
   } catch (error) {
     console.error("Token verification error:", error)

--- a/components/site-faq.tsx
+++ b/components/site-faq.tsx
@@ -7,7 +7,7 @@ const faqItems = [
   {
     question: "Where can I manage or cancel the newsletter?",
     answer:
-      "The unsubscribe hub is linked in the main navigation and footer. You can instantly opt out or adjust topic preferences without logging in.",
+      "Every email contains your personal unsubscribe link pointing to the /unsubscribe hub, which is also linked in the main navigation and footer. Open the link to see your subscribed address, then either confirm the one-click unsubscribe or toggle individual topics and save—no login required.",
   },
   {
     question: "How quickly will you respond to new contact requests?",

--- a/lib/newsletter.ts
+++ b/lib/newsletter.ts
@@ -128,12 +128,12 @@ export async function sendSubscriptionConfirmation(email: string, name: string, 
 }
 
 // Send welcome email after confirmation
-export async function sendWelcomeEmail(email: string, name: string) {
+export async function sendWelcomeEmail(email: string, name: string, token: string) {
   try {
     const transporter = await createTransporter()
     const emailConfig = await getEmailConfig()
     const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000"
-    const unsubscribeUrl = `${baseUrl}/unsubscribe`
+    const unsubscribeUrl = `${baseUrl}/unsubscribe${token ? `?token=${token}` : ""}`
 
     // Create email content
     const mailOptions = {


### PR DESCRIPTION
## Summary
- add robust verification and preference APIs that return subscriber details, defaults, and secure admin handling
- refine the unsubscribe client to guide users through verification, preference updates, and one-click removal states
- include personalized unsubscribe links in welcome emails and update the FAQ to document the process

## Testing
- pnpm lint
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_69050688eeac832ca94af1440859991a