### PR TITLE
Revamp marketing pages with richer storytelling

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image"
 import Link from "next/link"
-import { ArrowRight, FileCode2 } from "lucide-react"
+import { ArrowRight, BookOpenCheck, FileCode2, Globe, HeartHandshake, Target, Users } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
@@ -43,8 +43,9 @@ export default function AboutPage() {
                   <h1 className="text-3xl font-bold tracking-tighter sm:text-4xl md:text-5xl lg:text-6xl bg-clip-text text-transparent bg-gradient-to-r from-purple-600 to-blue-600">
                     About Me
                   </h1>
-                  <p className="mx-auto max-w-[700px] text-gray-500 md:text-xl dark:text-gray-400">
-                    Full Stack Developer with a passion for building modern web applications
+                  <p className="mx-auto max-w-[760px] text-gray-500 md:text-xl dark:text-gray-400">
+                    Full stack developer from Itzehoe, Germany, spotlighting the people and missions behind every digital
+                    product I build.
                   </p>
                 </div>
               </div>
@@ -69,9 +70,14 @@ export default function AboutPage() {
                       My Journey
                     </h2>
                     <p className="text-gray-500 md:text-xl/relaxed lg:text-base/relaxed xl:text-xl/relaxed dark:text-gray-400">
-                      I'm a passionate Full Stack Developer with over 10 years of experience
-                      building web applications. I specialize in React, Next.js, Node.js, and modern
-                      web technologies.
+                      I'm a passionate full stack developer with over 10 years of experience building web applications. I
+                      specialise in modern TypeScript tooling, React ecosystems, and scalable backend infrastructures that stay
+                      maintainable long after handover.
+                    </p>
+                    <p className="text-gray-500 md:text-lg/relaxed lg:text-base/relaxed xl:text-lg/relaxed dark:text-gray-400">
+                      My projects weave together strategy, design, and engineering. Whether it's a sports club managing
+                      thousands of members or a startup validating its first product, I translate complex requirements into
+                      approachable digital experiences.
                     </p>
                   </div>
                   <div className="space-y-2">
@@ -85,10 +91,33 @@ export default function AboutPage() {
                   <div className="space-y-2">
                     <h3 className="text-xl font-bold">Professional Experience</h3>
                     <p className="text-gray-500 dark:text-gray-400">
-                      I've worked with startups, clubs, and associations, helping them develop
-                      scalable and maintainable web applications. My focus is on creating
-                      exceptional user experiences with clean, efficient code.
+                      I've worked with startups, clubs, and associations, helping them develop scalable and maintainable web
+                      applications. My focus is on creating exceptional user experiences with clean, efficient code.
                     </p>
+                    <p className="text-gray-500 dark:text-gray-400">
+                      Outside of delivering client projects, I mentor aspiring developers, produce technical documentation, and
+                      contribute to open-source initiatives that keep European tech communities thriving.
+                    </p>
+                  </div>
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <Card className="bg-background/60 backdrop-blur-sm border-primary/20 shadow-lg">
+                      <CardContent className="p-4 space-y-2">
+                        <Users className="h-6 w-6 text-primary" />
+                        <h4 className="text-lg font-semibold">People-first mindset</h4>
+                        <p className="text-sm text-muted-foreground">
+                          I design workshops, onboarding flows, and documentation that empower teams and volunteers alike.
+                        </p>
+                      </CardContent>
+                    </Card>
+                    <Card className="bg-background/60 backdrop-blur-sm border-primary/20 shadow-lg">
+                      <CardContent className="p-4 space-y-2">
+                        <Globe className="h-6 w-6 text-primary" />
+                        <h4 className="text-lg font-semibold">International collaboration</h4>
+                        <p className="text-sm text-muted-foreground">
+                          Working across borders taught me to balance localisation, accessibility, and compliance from day one.
+                        </p>
+                      </CardContent>
+                    </Card>
                   </div>
                 </div>
               </div>
@@ -157,6 +186,103 @@ export default function AboutPage() {
                         PostgreSQL, MongoDB, MySQL, Docker, CI/CD, Git
                       </p>
                     </div>
+                  </CardContent>
+                </Card>
+              </div>
+            </div>
+          </section>
+
+          <section className="w-full py-12 md:py-24 lg:py-32 bg-muted/30 backdrop-blur-sm">
+            <div className="container px-4 md:px-6">
+              <div className="flex flex-col items-center justify-center space-y-4 text-center mb-12">
+                <div className="space-y-2">
+                  <h2 className="text-3xl font-bold tracking-tighter sm:text-4xl bg-clip-text text-transparent bg-gradient-to-r from-purple-600 to-blue-600">
+                    Values I bring to every collaboration
+                  </h2>
+                  <p className="mx-auto max-w-[760px] text-gray-500 md:text-xl dark:text-gray-400">
+                    My approach combines technical craftsmanship with empathy for the people relying on the final product.
+                  </p>
+                </div>
+              </div>
+
+              <div className="grid gap-6 md:grid-cols-3">
+                <Card className="bg-background/60 backdrop-blur-sm border-primary/20 shadow-lg hover:shadow-xl transition-all duration-300">
+                  <CardContent className="p-6 space-y-3">
+                    <Target className="h-8 w-8 text-primary" />
+                    <h3 className="text-xl font-semibold">Purpose-driven planning</h3>
+                    <p className="text-sm text-muted-foreground">
+                      I align development roadmaps with the goals of your members, customers, and partners so success feels
+                      tangible for everyone involved.
+                    </p>
+                  </CardContent>
+                </Card>
+                <Card className="bg-background/60 backdrop-blur-sm border-primary/20 shadow-lg hover:shadow-xl transition-all duration-300">
+                  <CardContent className="p-6 space-y-3">
+                    <HeartHandshake className="h-8 w-8 text-primary" />
+                    <h3 className="text-xl font-semibold">Transparent collaboration</h3>
+                    <p className="text-sm text-muted-foreground">
+                      From weekly demos to accessible documentation, I keep every stakeholder informed and empowered to make
+                      confident decisions.
+                    </p>
+                  </CardContent>
+                </Card>
+                <Card className="bg-background/60 backdrop-blur-sm border-primary/20 shadow-lg hover:shadow-xl transition-all duration-300">
+                  <CardContent className="p-6 space-y-3">
+                    <BookOpenCheck className="h-8 w-8 text-primary" />
+                    <h3 className="text-xl font-semibold">Continuous learning</h3>
+                    <p className="text-sm text-muted-foreground">
+                      I invest in ongoing education, share lessons publicly, and bring that knowledge into every engagement I
+                      lead.
+                    </p>
+                  </CardContent>
+                </Card>
+              </div>
+            </div>
+          </section>
+
+          <section className="w-full py-12 md:py-24 lg:py-32">
+            <div className="container px-4 md:px-6">
+              <div className="flex flex-col items-center justify-center space-y-4 text-center mb-12">
+                <div className="space-y-2">
+                  <h2 className="text-3xl font-bold tracking-tighter sm:text-4xl bg-clip-text text-transparent bg-gradient-to-r from-purple-600 to-blue-600">
+                    Beyond the screen
+                  </h2>
+                  <p className="mx-auto max-w-[760px] text-gray-500 md:text-xl dark:text-gray-400">
+                    I believe great products reflect their communities, so I stay close to grassroots initiatives and creative
+                    circles.
+                  </p>
+                </div>
+              </div>
+
+              <div className="grid gap-8 md:grid-cols-3">
+                <Card className="bg-background/60 backdrop-blur-sm border-primary/20 shadow-lg">
+                  <CardContent className="p-6 space-y-2 text-left">
+                    <Users className="h-8 w-8 text-primary" />
+                    <h3 className="text-xl font-semibold">Community mentorship</h3>
+                    <p className="text-sm text-muted-foreground">
+                      I mentor students and junior developers, helping them navigate real-world projects and contribute to
+                      open-source safely.
+                    </p>
+                  </CardContent>
+                </Card>
+                <Card className="bg-background/60 backdrop-blur-sm border-primary/20 shadow-lg">
+                  <CardContent className="p-6 space-y-2 text-left">
+                    <Globe className="h-8 w-8 text-primary" />
+                    <h3 className="text-xl font-semibold">Local initiatives</h3>
+                    <p className="text-sm text-muted-foreground">
+                      In Itzehoe, I collaborate with associations to digitalise workflows and showcase the people keeping our
+                      region vibrant.
+                    </p>
+                  </CardContent>
+                </Card>
+                <Card className="bg-background/60 backdrop-blur-sm border-primary/20 shadow-lg">
+                  <CardContent className="p-6 space-y-2 text-left">
+                    <FileCode2 className="h-8 w-8 text-primary" />
+                    <h3 className="text-xl font-semibold">Story-driven writing</h3>
+                    <p className="text-sm text-muted-foreground">
+                      I publish case studies and technical deep dives that celebrate collaborators while demystifying the code
+                      powering their success.
+                    </p>
                   </CardContent>
                 </Card>
               </div>

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -4,7 +4,18 @@ import type React from "react"
 
 import Link from "next/link"
 import { useState } from "react"
-import { MapPin, Phone, Mail, User, Tag, MessageSquare } from "lucide-react"
+import {
+  Clock,
+  HeartHandshake,
+  Lightbulb,
+  MapPin,
+  MessageSquare,
+  NotebookPen,
+  Phone,
+  Mail,
+  Tag,
+  User,
+} from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
@@ -170,6 +181,32 @@ export default function ContactPage() {
                       </CardContent>
                     </Card>
                   </div>
+                  <Card className="bg-background/60 backdrop-blur-sm border-primary/20 shadow-lg">
+                    <CardContent className="p-6 space-y-4">
+                      <div className="flex items-center gap-3">
+                        <Clock className="h-6 w-6 text-primary" />
+                        <h3 className="text-xl font-semibold">What happens after you reach out</h3>
+                      </div>
+                      <p className="text-sm text-muted-foreground">
+                        Every enquiry lands directly in my inbox. I review project details personally before we jump on a call so
+                        the conversation focuses on solutions, not introductions.
+                      </p>
+                      <div className="space-y-2 text-sm text-muted-foreground">
+                        <div className="flex items-start gap-2">
+                          <Lightbulb className="mt-0.5 h-4 w-4 text-primary" />
+                          <span>Share your mission, current challenges, and desired launch window—context helps me prepare.</span>
+                        </div>
+                        <div className="flex items-start gap-2">
+                          <NotebookPen className="mt-0.5 h-4 w-4 text-primary" />
+                          <span>You'll receive a summary of our discussion with next steps, timelines, and responsibilities.</span>
+                        </div>
+                        <div className="flex items-start gap-2">
+                          <HeartHandshake className="mt-0.5 h-4 w-4 text-primary" />
+                          <span>We collaborate transparently—no hidden costs, and you keep full access to code and documentation.</span>
+                        </div>
+                      </div>
+                    </CardContent>
+                  </Card>
                 </div>
                 <div>
                   <Card className="bg-background/60 backdrop-blur-sm border-primary/20 shadow-lg">
@@ -268,6 +305,49 @@ export default function ContactPage() {
                     </CardContent>
                   </Card>
                 </div>
+              </div>
+            </div>
+          </section>
+
+          <section className="w-full py-12 md:py-24 lg:py-32 bg-muted/30 backdrop-blur-sm">
+            <div className="container px-4 md:px-6">
+              <div className="grid gap-12 md:grid-cols-[1.2fr_1fr] md:items-center">
+                <div className="space-y-6">
+                  <h2 className="text-3xl font-bold tracking-tighter sm:text-4xl md:text-5xl bg-clip-text text-transparent bg-gradient-to-r from-purple-600 to-blue-600">
+                    Let's tell your story together
+                  </h2>
+                  <p className="text-gray-500 md:text-xl/relaxed dark:text-gray-400">
+                    I'm passionate about spotlighting the people behind every initiative. Whether you represent a sports club,
+                    an association, or an early-stage startup, we'll co-create digital touchpoints that reflect your culture and
+                    aspirations.
+                  </p>
+                  <p className="text-gray-500 md:text-lg/relaxed dark:text-gray-400">
+                    If you're unsure where to start, share your current stack or favourite toolset—I can audit your setup and
+                    suggest small but high-impact changes before we plan a full project.
+                  </p>
+                </div>
+                <Card className="bg-background/60 backdrop-blur-sm border-primary/20 shadow-lg">
+                  <CardContent className="p-6 space-y-4">
+                    <h3 className="text-xl font-semibold">Helpful resources</h3>
+                    <p className="text-sm text-muted-foreground">
+                      These links offer a deeper look at how I work and what to expect.
+                    </p>
+                    <div className="grid gap-3">
+                      <Link
+                        href="/projects"
+                        className="text-sm font-medium text-primary underline-offset-4 hover:underline"
+                      >
+                        Explore detailed project breakdowns
+                      </Link>
+                      <Link href="/about" className="text-sm font-medium text-primary underline-offset-4 hover:underline">
+                        Learn more about my background
+                      </Link>
+                      <Link href="/#faq" className="text-sm font-medium text-primary underline-offset-4 hover:underline">
+                        Read common questions and support options
+                      </Link>
+                    </div>
+                  </CardContent>
+                </Card>
               </div>
             </div>
           </section>

--- a/app/newsletter/page.tsx
+++ b/app/newsletter/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next"
 import Link from "next/link"
-import { CheckCircle, Inbox, MailPlus, ShieldCheck } from "lucide-react"
+import { CheckCircle, Inbox, MailPlus, ShieldCheck, Sparkles, Users } from "lucide-react"
 
 import { MainNav } from "@/components/main-nav"
 import { SiteFooter } from "@/components/site-footer"
@@ -44,6 +44,11 @@ export default function NewsletterPage() {
                   <p className="mx-auto max-w-[700px] text-gray-500 md:text-xl dark:text-gray-400">
                     Choose what you receive, try new features early, and unsubscribe instantly—no buried links.
                   </p>
+                  <p className="mx-auto max-w-[760px] text-gray-500 md:text-lg dark:text-gray-400">
+                    I share behind-the-scenes notes from client projects, reflections on community work in Itzehoe, and early
+                    prototypes you can test before public launches. You'll always know who's writing, why it matters, and how to
+                    respond.
+                  </p>
                 </div>
               </div>
               <div className="mt-12 grid gap-8 lg:grid-cols-[2fr_3fr]">
@@ -67,11 +72,11 @@ export default function NewsletterPage() {
                     <div className="rounded-lg border border-dashed border-primary/40 bg-primary/5 p-4 text-left text-sm text-muted-foreground">
                       <p className="font-medium text-primary">Already on the list?</p>
                       <p>
-                        Jump straight to the
-                        <Link href="/unsubscribe" className="font-medium text-primary underline-offset-4 hover:underline">
-                          subscription manager
+                        Every email includes your personal link to manage preferences. Need it again? Follow the steps in the
+                        <Link href="/#faq" className="font-medium text-primary underline-offset-4 hover:underline">
+                          newsletter FAQ
                         </Link>{" "}
-                        to update preferences or opt out.
+                        or visit the subscription manager directly when you have your token ready.
                       </p>
                     </div>
                   </CardContent>
@@ -112,6 +117,43 @@ export default function NewsletterPage() {
                     <h3 className="text-lg font-semibold">Feedback welcome</h3>
                     <p className="text-sm text-muted-foreground">
                       Reply to any email or use the contact form to shape future topics.
+                    </p>
+                  </CardContent>
+                </Card>
+              </div>
+            </div>
+          </section>
+
+          <section className="w-full py-12 md:py-24 lg:py-32">
+            <div className="container px-4 md:px-6">
+              <div className="flex flex-col items-center justify-center space-y-4 text-center mb-12">
+                <div className="space-y-2">
+                  <h2 className="text-3xl font-bold tracking-tighter sm:text-4xl md:text-5xl bg-clip-text text-transparent bg-gradient-to-r from-purple-600 to-blue-600">
+                    What subscribers receive
+                  </h2>
+                  <p className="mx-auto max-w-[760px] text-gray-500 md:text-xl dark:text-gray-400">
+                    My emails are intentional, occasional, and crafted to represent the collaborations I'm proud of.
+                  </p>
+                </div>
+              </div>
+
+              <div className="grid gap-8 md:grid-cols-2">
+                <Card className="bg-background/60 backdrop-blur-sm border-primary/20 shadow-lg">
+                  <CardContent className="p-6 space-y-3 text-left">
+                    <Sparkles className="h-8 w-8 text-primary" />
+                    <h3 className="text-xl font-semibold">In-depth breakdowns</h3>
+                    <p className="text-sm text-muted-foreground">
+                      Discover the decisions behind recent launches, complete with architecture diagrams, accessibility notes,
+                      and performance insights.
+                    </p>
+                  </CardContent>
+                </Card>
+                <Card className="bg-background/60 backdrop-blur-sm border-primary/20 shadow-lg">
+                  <CardContent className="p-6 space-y-3 text-left">
+                    <Users className="h-8 w-8 text-primary" />
+                    <h3 className="text-xl font-semibold">Community invitations</h3>
+                    <p className="text-sm text-muted-foreground">
+                      Join beta programmes, office hours, and collaborative sessions where we shape upcoming features together.
                     </p>
                   </CardContent>
                 </Card>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,20 @@
 import type { Metadata } from "next"
 import { Suspense } from "react"
 import Link from "next/link"
-import { ArrowRight, Mail, MessageCircle, UserPlus } from "lucide-react"
+import {
+  ArrowRight,
+  Award,
+  Compass,
+  Globe,
+  Layers,
+  Mail,
+  MessageCircle,
+  Rocket,
+  Sparkles,
+  Target,
+  UserPlus,
+  Users,
+} from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import { FeaturedProjects } from "@/components/featured-projects"
@@ -53,10 +66,11 @@ export default async function Home() {
               <div className="flex flex-col items-center justify-center space-y-4 text-center">
                 <div className="space-y-2 animate-fade-in">
                   <h1 className="text-4xl font-bold tracking-tighter sm:text-5xl md:text-6xl lg:text-7xl bg-clip-text text-transparent bg-gradient-to-r from-purple-600 via-blue-600 to-cyan-600">
-                    Full Stack Developer
+                    Purposeful digital experiences by Tim Hauke
                   </h1>
-                  <p className="mx-auto max-w-[700px] text-gray-500 md:text-xl dark:text-gray-400">
-                    Building modern web applications with cutting-edge technologies
+                  <p className="mx-auto max-w-[760px] text-gray-500 md:text-xl dark:text-gray-400">
+                    I partner with clubs, associations, and ambitious founders to transform ideas into reliable web products
+                    that feel personal, perform at scale, and stay easy to maintain long after launch.
                   </p>
                 </div>
                 <div className="flex flex-wrap items-center justify-center gap-4 animate-slide-in">
@@ -74,6 +88,105 @@ export default async function Home() {
                     </Button>
                   </Link>
                 </div>
+              </div>
+            </div>
+          </section>
+
+          <section className="w-full py-12 md:py-24 lg:py-32">
+            <div className="container px-4 md:px-6">
+              <div className="grid gap-12 lg:grid-cols-[1.35fr_1fr] lg:items-start">
+                <div className="space-y-6">
+                  <h2 className="text-3xl font-bold tracking-tighter sm:text-4xl md:text-5xl bg-clip-text text-transparent bg-gradient-to-r from-purple-600 to-blue-600">
+                    Meet the builder behind the work
+                  </h2>
+                  <p className="text-gray-500 md:text-xl/relaxed dark:text-gray-400">
+                    I'm a full stack developer based in Itzehoe, Germany, with a passion for designing resilient systems and
+                    inviting communities into the process. From non-profits that rely on reliable infrastructure to companies
+                    shipping their first SaaS product, I translate complex requirements into friendly, future-proof software.
+                  </p>
+                  <p className="text-gray-500 md:text-lg/relaxed dark:text-gray-400">
+                    My work blends technical depth with storytelling. Every interface should highlight the humans behind a
+                    project—so I document decisions, surface impact metrics, and make sure clients can continue the story once a
+                    project is delivered.
+                  </p>
+                  <div className="grid gap-6 sm:grid-cols-2">
+                    <Card className="bg-background/60 backdrop-blur-sm border-primary/20 shadow-lg hover:shadow-xl transition-all duration-300">
+                      <CardContent className="p-6 space-y-2">
+                        <Award className="h-8 w-8 text-primary" />
+                        <h3 className="text-xl font-semibold">Seasoned delivery</h3>
+                        <p className="text-sm text-muted-foreground">
+                          Over a decade of iterating on web platforms, internal tools, and membership portals with measurable
+                          results.
+                        </p>
+                      </CardContent>
+                    </Card>
+                    <Card className="bg-background/60 backdrop-blur-sm border-primary/20 shadow-lg hover:shadow-xl transition-all duration-300">
+                      <CardContent className="p-6 space-y-2">
+                        <Globe className="h-8 w-8 text-primary" />
+                        <h3 className="text-xl font-semibold">European perspective</h3>
+                        <p className="text-sm text-muted-foreground">
+                          Collaborating with organisations across Germany and neighbouring countries with multilingual, GDPR-ready
+                          experiences.
+                        </p>
+                      </CardContent>
+                    </Card>
+                    <Card className="bg-background/60 backdrop-blur-sm border-primary/20 shadow-lg hover:shadow-xl transition-all duration-300">
+                      <CardContent className="p-6 space-y-2">
+                        <Users className="h-8 w-8 text-primary" />
+                        <h3 className="text-xl font-semibold">Community driven</h3>
+                        <p className="text-sm text-muted-foreground">
+                          I design onboarding, feedback loops, and moderation workflows that help members feel seen and heard.
+                        </p>
+                      </CardContent>
+                    </Card>
+                    <Card className="bg-background/60 backdrop-blur-sm border-primary/20 shadow-lg hover:shadow-xl transition-all duration-300">
+                      <CardContent className="p-6 space-y-2">
+                        <Sparkles className="h-8 w-8 text-primary" />
+                        <h3 className="text-xl font-semibold">Crafted details</h3>
+                        <p className="text-sm text-muted-foreground">
+                          From accessibility to microcopy, I sweat the small things so every release feels intentional and polished.
+                        </p>
+                      </CardContent>
+                    </Card>
+                  </div>
+                  <div className="flex flex-wrap gap-3">
+                    <Link href="/about">
+                      <Button className="gap-2 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700">
+                        Learn more about my story <ArrowRight className="h-4 w-4" />
+                      </Button>
+                    </Link>
+                    <Link href="/projects">
+                      <Button
+                        variant="outline"
+                        className="gap-2 border-purple-600/50 hover:border-purple-600"
+                      >
+                        Explore client outcomes <ArrowRight className="h-4 w-4" />
+                      </Button>
+                    </Link>
+                  </div>
+                </div>
+                <Card className="bg-background/60 backdrop-blur-sm border-primary/20 shadow-lg">
+                  <CardContent className="p-6 space-y-4">
+                    <h3 className="text-xl font-semibold">What collaboration looks like</h3>
+                    <p className="text-sm text-muted-foreground">
+                      Each engagement is transparent, structured, and shaped around your stakeholders.
+                    </p>
+                    <div className="space-y-3 text-sm text-muted-foreground">
+                      <div className="flex items-start gap-2">
+                        <Target className="mt-0.5 h-4 w-4 text-primary" />
+                        <span>Workshops to align on user value, success metrics, and long-term maintainability.</span>
+                      </div>
+                      <div className="flex items-start gap-2">
+                        <Layers className="mt-0.5 h-4 w-4 text-primary" />
+                        <span>Composable architectures that keep future iterations predictable and well-tested.</span>
+                      </div>
+                      <div className="flex items-start gap-2">
+                        <Sparkles className="mt-0.5 h-4 w-4 text-primary" />
+                        <span>Launch assets, changelog updates, and documentation that empower your team.</span>
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
               </div>
             </div>
           </section>
@@ -157,6 +270,52 @@ export default async function Home() {
 
           <section className="w-full py-12 md:py-24 lg:py-32">
             <div className="container px-4 md:px-6">
+              <div className="flex flex-col items-center justify-center space-y-4 text-center mb-12">
+                <div className="space-y-2">
+                  <h2 className="text-3xl font-bold tracking-tighter sm:text-4xl md:text-5xl bg-clip-text text-transparent bg-gradient-to-r from-purple-600 to-blue-600">
+                    How I turn requirements into results
+                  </h2>
+                  <p className="mx-auto max-w-[760px] text-gray-500 md:text-xl dark:text-gray-400">
+                    Clear communication, focused experiments, and measurable outcomes keep every collaboration moving forward.
+                  </p>
+                </div>
+              </div>
+
+              <div className="grid gap-6 md:grid-cols-3">
+                <Card className="bg-background/60 backdrop-blur-sm border-primary/20 shadow-lg hover:shadow-xl transition-all duration-300">
+                  <CardContent className="p-6 space-y-3 text-left">
+                    <Compass className="h-8 w-8 text-primary" />
+                    <h3 className="text-xl font-semibold">Discover the story</h3>
+                    <p className="text-sm text-muted-foreground">
+                      I start by mapping stakeholders, constraints, and existing systems to uncover the narrative behind your
+                      product.
+                    </p>
+                  </CardContent>
+                </Card>
+                <Card className="bg-background/60 backdrop-blur-sm border-primary/20 shadow-lg hover:shadow-xl transition-all duration-300">
+                  <CardContent className="p-6 space-y-3 text-left">
+                    <Layers className="h-8 w-8 text-primary" />
+                    <h3 className="text-xl font-semibold">Design the architecture</h3>
+                    <p className="text-sm text-muted-foreground">
+                      Wireframes, component systems, and APIs are aligned early so development flows smoothly across teams.
+                    </p>
+                  </CardContent>
+                </Card>
+                <Card className="bg-background/60 backdrop-blur-sm border-primary/20 shadow-lg hover:shadow-xl transition-all duration-300">
+                  <CardContent className="p-6 space-y-3 text-left">
+                    <Rocket className="h-8 w-8 text-primary" />
+                    <h3 className="text-xl font-semibold">Launch, learn, iterate</h3>
+                    <p className="text-sm text-muted-foreground">
+                      After launch I analyse engagement, document improvements, and plan the next release with your team.
+                    </p>
+                  </CardContent>
+                </Card>
+              </div>
+            </div>
+          </section>
+
+          <section className="w-full py-12 md:py-24 lg:py-32">
+            <div className="container px-4 md:px-6">
               <div className="grid gap-10 lg:grid-cols-2 lg:gap-16 items-center">
                 <div className="space-y-6">
                   <h2 className="text-3xl font-bold tracking-tighter sm:text-4xl md:text-5xl bg-clip-text text-transparent bg-gradient-to-r from-purple-600 to-blue-600">
@@ -205,9 +364,9 @@ export default async function Home() {
                             <UserPlus className="h-4 w-4" /> Register to comment
                           </Button>
                         </Link>
-                        <Link href="/unsubscribe">
+                        <Link href="/#faq">
                           <Button variant="ghost" className="w-full gap-2 text-primary hover:text-primary">
-                            Manage newsletter settings
+                            Newsletter FAQ & unsubscribe help
                           </Button>
                         </Link>
                       </div>

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,4 +1,6 @@
 import { Suspense } from "react"
+import { Lightbulb, LineChart, Users, Zap } from "lucide-react"
+
 import { MainNav } from "@/components/main-nav"
 import { SiteFooter } from "@/components/site-footer"
 import { BackgroundGradientAnimation } from "@/components/ui/background-gradient-animation"
@@ -47,14 +49,111 @@ export default function ProjectsPage() {
                 </div>
               </div>
 
+              <div className="mx-auto max-w-3xl space-y-4 text-center text-gray-500 md:text-lg dark:text-gray-400">
+                <p>
+                  Each case study captures more than a feature list—it documents the mission behind the build, the community it
+                  serves, and the measurable impact delivered after launch. I combine clean design systems with sustainable
+                  backend choices so clients inherit software they can confidently evolve.
+                </p>
+                <p>
+                  Explore a mix of membership platforms, operational dashboards, and bespoke automations created for clubs,
+                  associations, and founders across Europe. When you're ready, reach out and we'll map how these approaches can
+                  accelerate your vision.
+                </p>
+              </div>
+
+              <div className="mt-12 grid gap-6 md:grid-cols-3">
+                <Card className="bg-background/60 backdrop-blur-sm border-primary/20 shadow-lg hover:shadow-xl transition-all duration-300">
+                  <CardContent className="p-6 space-y-3 text-left">
+                    <Lightbulb className="h-8 w-8 text-primary" />
+                    <h3 className="text-xl font-semibold">Strategy first</h3>
+                    <p className="text-sm text-muted-foreground">
+                      Workshops and discovery sessions shape a roadmap tied to real KPIs, not vanity metrics.
+                    </p>
+                  </CardContent>
+                </Card>
+                <Card className="bg-background/60 backdrop-blur-sm border-primary/20 shadow-lg hover:shadow-xl transition-all duration-300">
+                  <CardContent className="p-6 space-y-3 text-left">
+                    <Users className="h-8 w-8 text-primary" />
+                    <h3 className="text-xl font-semibold">Human-centric UX</h3>
+                    <p className="text-sm text-muted-foreground">
+                      Interfaces are prototyped with stakeholder feedback so communities recognise themselves on screen.
+                    </p>
+                  </CardContent>
+                </Card>
+                <Card className="bg-background/60 backdrop-blur-sm border-primary/20 shadow-lg hover:shadow-xl transition-all duration-300">
+                  <CardContent className="p-6 space-y-3 text-left">
+                    <LineChart className="h-8 w-8 text-primary" />
+                    <h3 className="text-xl font-semibold">Measurable growth</h3>
+                    <p className="text-sm text-muted-foreground">
+                      Launch retrospectives include engagement dashboards and documentation that keep improvements on track.
+                    </p>
+                  </CardContent>
+                </Card>
+              </div>
+
               <Suspense fallback={<ProjectsSkeleton />}>
                 <ProjectsGrid />
               </Suspense>
 
-              <div className="mt-24 mb-12">
+              <div className="mt-24 space-y-6 text-gray-500 md:text-lg dark:text-gray-400">
+                <p>
+                  You will find both solo builds and collaborative efforts here. I highlight the roles I played—from product
+                  strategy to deployment automation—so you can see exactly how I plug into multidisciplinary teams.
+                </p>
+                <p>
+                  Curious about a specific implementation detail? Use the contact page to request private architecture notes or
+                  extended documentation—I'm happy to dive deeper.
+                </p>
+              </div>
+
+              <div className="mt-16 mb-12">
                 <Card className="border border-purple-200 dark:border-purple-800 bg-background/60 backdrop-blur-sm">
                   <CardContent className="pt-6">
                     <NewsletterForm />
+                  </CardContent>
+                </Card>
+              </div>
+            </div>
+          </section>
+
+          <section className="w-full py-12 md:py-24 lg:py-32 bg-muted/30 backdrop-blur-sm">
+            <div className="container px-4 md:px-6">
+              <div className="grid gap-12 md:grid-cols-[1.2fr_1fr] md:items-start">
+                <div className="space-y-6">
+                  <h2 className="text-3xl font-bold tracking-tighter sm:text-4xl md:text-5xl bg-clip-text text-transparent bg-gradient-to-r from-purple-600 to-blue-600">
+                    Behind every showcase is a partnership
+                  </h2>
+                  <p className="text-gray-500 md:text-xl/relaxed dark:text-gray-400">
+                    I work closely with project leads to surface the people involved—the volunteers, administrators, and
+                    customers powering each release. Expect transparent updates, collaborative tooling, and documentation that
+                    puts names and faces next to milestones.
+                  </p>
+                  <p className="text-gray-500 md:text-lg/relaxed dark:text-gray-400">
+                    Ready to start yours? Let's discuss timelines, technical requirements, and the story you want your audience
+                    to remember.
+                  </p>
+                </div>
+                <Card className="bg-background/60 backdrop-blur-sm border-primary/20 shadow-lg hover:shadow-xl transition-all duration-300">
+                  <CardContent className="p-6 space-y-3 text-left">
+                    <h3 className="text-xl font-semibold">Project essentials</h3>
+                    <p className="text-sm text-muted-foreground">
+                      Every engagement includes these foundations to keep momentum high.
+                    </p>
+                    <ul className="space-y-2 text-sm text-muted-foreground">
+                      <li className="flex items-start gap-2">
+                        <Lightbulb className="mt-0.5 h-4 w-4 text-primary" />
+                        Discovery workshop with stakeholder mapping and success metrics.
+                      </li>
+                      <li className="flex items-start gap-2">
+                        <Zap className="mt-0.5 h-4 w-4 text-primary" />
+                        Iterative delivery with preview environments for quick feedback.
+                      </li>
+                      <li className="flex items-start gap-2">
+                        <LineChart className="mt-0.5 h-4 w-4 text-primary" />
+                        Post-launch analytics summary and action plan for the next sprint.
+                      </li>
+                    </ul>
                   </CardContent>
                 </Card>
               </div>

--- a/components/main-nav.tsx
+++ b/components/main-nav.tsx
@@ -49,7 +49,6 @@ export function MainNav() {
     { href: "/about", label: "About" },
     { href: "/contact", label: "Contact" },
     { href: "/newsletter", label: "Newsletter" },
-    { href: "/unsubscribe", label: "Unsubscribe" },
   ]
 
   const handleLogout = async () => {

--- a/components/site-faq.tsx
+++ b/components/site-faq.tsx
@@ -7,7 +7,7 @@ const faqItems = [
   {
     question: "Where can I manage or cancel the newsletter?",
     answer:
-      "Every email contains your personal unsubscribe link pointing to the /unsubscribe hub, which is also linked in the main navigation and footer. Open the link to see your subscribed address, then either confirm the one-click unsubscribe or toggle individual topics and save—no login required.",
+      "Every email contains your personal unsubscribe link pointing to the /unsubscribe hub. Whenever you need a reminder, come back to this FAQ: open the link in the message to see your subscribed address, then either confirm the one-click unsubscribe or toggle individual topics and save—no login required.",
   },
   {
     question: "How quickly will you respond to new contact requests?",
@@ -36,7 +36,7 @@ export function SiteFAQ() {
   }
 
   return (
-    <section className="w-full py-12 md:py-24 lg:py-32">
+    <section id="faq" className="w-full py-12 md:py-24 lg:py-32">
       <div className="container px-4 md:px-6">
         <div className="flex flex-col items-center justify-center space-y-4 text-center mb-12">
           <div className="space-y-2">

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -22,8 +22,8 @@ export function SiteFooter() {
             <Link href="/newsletter" className="hover:text-primary hover:underline underline-offset-4">
               Newsletter
             </Link>
-            <Link href="/unsubscribe" className="hover:text-primary hover:underline underline-offset-4">
-              Manage Subscription
+            <Link href="/#faq" className="hover:text-primary hover:underline underline-offset-4">
+              Newsletter FAQ
             </Link>
             <Link href="/register" className="hover:text-primary hover:underline underline-offset-4">
               Join to Comment


### PR DESCRIPTION
## Summary
- remove the unsubscribe link from the main navigation and direct footer/CTA links to the FAQ guidance instead
- expand the home, projects, about, contact, and newsletter pages with richer copy and new sections that better represent Tim Hauke
- refresh the FAQ entry about subscription management to explain the email-based flow and anchor the section for quick access

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_69050ab40130832caa1374dc75a3ac45