### PR TITLE
docs: refresh portfolio documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing Guide
 
-Thank you for your interest in improving the Portfolio platform! This document outlines the recommended workflow, development standards, and expectations for contributions of any size.
+Thank you for your interest in improving the Portfolio platform! This document captures the recommended workflow, development standards, and expectations for contributions of any size.
 
 ## Table of Contents
 
@@ -9,6 +9,8 @@ Thank you for your interest in improving the Portfolio platform! This document o
 - [Workflow](#workflow)
 - [Coding Standards](#coding-standards)
 - [Database Changes](#database-changes)
+- [Email & Notification Testing](#email--notification-testing)
+- [Testing & Quality Gates](#testing--quality-gates)
 - [Commit Messages](#commit-messages)
 - [Pull Requests](#pull-requests)
 - [Issue Reporting](#issue-reporting)
@@ -16,78 +18,96 @@ Thank you for your interest in improving the Portfolio platform! This document o
 
 ## Before You Start
 
-- Review the [README](./README.md) to understand the project's architecture and feature set.
-- Ensure there is an existing GitHub issue describing the change or create one before starting significant work.
-- For large or breaking changes, open a discussion issue or draft PR first to align on direction.
+- Review the [README](./README.md) to understand the architecture, feature set, and environment requirements.
+- Look for existing GitHub issues or discussions covering the work you intend to ship. Open an issue first for larger or breaking changes so the approach can be aligned upfront.
+- For security-sensitive changes, coordinate privately using the channels described in [SECURITY.md](./SECURITY.md).
 
 ## Development Environment
 
 1. Fork the repository and clone your fork locally.
-2. Enable pnpm (if necessary) and install dependencies:
+2. Enable pnpm (if needed) and install dependencies:
    ```bash
-   corepack enable
+   corepack enable pnpm
    pnpm install
    ```
-3. Create a `.env` file based on the environment variable guidance in the README and provide values for authentication, database, and email settings.
-4. Set up a local MySQL instance and apply Prisma migrations:
+3. Copy `.env.example` if provided or create `.env` using the environment variable matrix in the README. At minimum, set `DATABASE_URL`, `NEXTAUTH_SECRET`, and `NEXTAUTH_URL`.
+4. Provision a MySQL database (local Docker container is fine) and apply migrations:
    ```bash
    pnpm prisma:generate
    pnpm prisma:migrate
    ```
-5. Run the development server with `pnpm dev` and ensure you can sign in via NextAuth.
+5. Seed development data if helpful by starting the dev server and running `curl -X POST http://localhost:3000/api/seed`. This creates an admin user plus sample portfolio records.
+6. Launch the development server with `pnpm dev` and confirm you can sign in via the seeded credentials or newly registered account.
+
+> **Tip:** The project writes uploaded media to `public/uploads/` and log files to `logs/`. Add both folders to your `.gitignore` or clean them before committing.
 
 ## Workflow
 
-1. Create a feature branch from `main` using a descriptive name (e.g., `feature/newsletter-segmentation` or `fix/contact-form-validation`).
-2. Make focused commits that keep the codebase buildable at each step.
-3. Keep your branch up to date with `main` by rebasing or merging frequently.
-4. When ready, open a pull request against `main` and request review.
+1. Create a feature branch from `main` (`feature/improve-analytics`, `fix/contact-form-validation`, etc.).
+2. Make incremental commits that keep the application buildable and the Prisma schema in sync with the database.
+3. Rebase or merge `main` regularly to avoid long-lived drift.
+4. When ready, open a pull request against `main` and request review from a maintainer.
 
 ## Coding Standards
 
-- Follow TypeScript best practices and avoid using `any` unless absolutely necessary.
-- Prefer functional components, hooks, and Next.js App Router conventions.
-- Reuse existing design system components where possible to maintain consistency.
-- Validate user input with Zod schemas or server-side guards before persisting to the database.
-- Keep server-only code in the appropriate files (`app/api/*`, server components, or `lib/`) and avoid leaking secrets to the client bundle.
-- Run the following scripts before pushing:
-  ```bash
-  pnpm lint
-  pnpm typecheck
-  pnpm format:check
-  ```
+- Write idiomatic, strongly-typed TypeScript. Avoid `any` unless absolutely necessary and justified in a code comment.
+- Prefer React Server Components and Server Actions where they fit the App Router model; use client components only when interactivity is required.
+- Reuse existing UI primitives in `components/ui/*` and `components/dashboard/*`. Add new primitives deliberately so the design system stays cohesive.
+- Validate inputs with Zod (see existing API handlers) and handle error states gracefully on the client.
+- Keep server-only logic in API routes, server components, or `lib/`. Do not leak secrets to client bundles.
+- Update documentation (README, API docs, environment tables) whenever you introduce new environment variables, commands, or workflows.
 
 ## Database Changes
 
-- Modify `prisma/schema.prisma` and run `pnpm prisma:migrate dev --name descriptive-migration` to generate a new migration.
-- Review generated SQL for accuracy and safety before committing.
-- Include updated Prisma client artifacts by running `pnpm prisma:generate`.
-- Document schema changes in your pull request summary.
+- Edit `prisma/schema.prisma` and create a migration with `pnpm prisma:migrate dev --name descriptive-migration`.
+- Inspect generated SQL for correctness and data safety before committing.
+- Regenerate the Prisma client (`pnpm prisma:generate`) after schema changes.
+- Include sample data updates or seeding scripts when your change relies on new reference data.
+- Describe the impact of the migration in your pull request, including any manual steps operators must perform.
+
+## Email & Notification Testing
+
+- By default, development email uses Ethereal credentials. Check the console for preview URLs when exercising `lib/email.ts` or newsletter flows.
+- When working on SMTP integration, use the dashboard settings UI (`/dashboard/settings`) to supply credentials instead of hard-coding secrets.
+- Avoid committing real SMTP credentials or inbox transcripts. Use `.env` and secrets managers.
+
+## Testing & Quality Gates
+
+Run the following commands before pushing:
+
+```bash
+pnpm lint
+pnpm typecheck
+pnpm format:check
+pnpm validate      # optional shortcut for lint + typecheck
+```
+
+- Use `pnpm lint:fix` and `pnpm format` to resolve style issues automatically.
+- For behavioural changes, add or update unit/component tests when feasible. If automated coverage is impractical, describe manual verification steps in the PR.
 
 ## Commit Messages
 
-- Use the imperative mood (e.g., `Add dashboard analytics cards`).
-- Keep subject lines under 72 characters when possible.
-- Provide additional context in the body for complex changes or breaking updates.
+- Use the imperative mood (`Add dashboard analytics cards`, `Fix contact status transitions`).
+- Keep subject lines under ~72 characters when possible.
+- Provide additional context in the body for complex changes, migrations, or breaking adjustments.
 
 ## Pull Requests
 
-- Fill in the PR template if available, including a clear summary, testing evidence, and screenshots for UI changes.
+- Fill out the PR template (if present) with a concise summary, screenshots for UI changes, and explicit testing evidence.
 - Reference related issues using GitHub keywords (`Fixes #123`).
-- Include notes about migrations, environment variable additions, or configuration updates.
-- Ensure CI checks pass before requesting a review.
-- Be responsive to review feedback and keep the discussion focused on the change at hand.
+- Call out new environment variables, migrations, or operational runbooks so deployers can react.
+- Ensure CI checks pass before requesting a review. Address feedback promptly and keep conversations focused on the change set.
 
 ## Issue Reporting
 
-- Search existing issues before creating a new one to avoid duplicates.
-- Provide reproducible steps, expected vs. actual behavior, and environment details (browser, OS, Node version).
-- For security concerns, follow the [Security Policy](./SECURITY.md) instead of filing a public issue.
+- Search existing issues to avoid duplicates.
+- Include reproducible steps, expected vs. actual behaviour, browser/OS, and Node.js version information.
+- For security vulnerabilities, use the private disclosure channels defined in [SECURITY.md](./SECURITY.md) instead of public issues.
 
 ## Community Expectations
 
-- Be respectful and inclusive. Constructive feedback and shared learning are core values.
-- Assume positive intent in reviews and discussions.
-- Credit the work of others when building on their contributions.
+- Be respectful and inclusive. Constructive feedback and knowledge sharing are valued.
+- Assume positive intent when reviewing or responding to comments.
+- Credit previous contributors when building on their work.
 
 We appreciate your time and effort in making the Portfolio platform better for everyone!

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # Portfolio Platform
 
-A full-stack personal portfolio and content management platform built with **Next.js 15**, **TypeScript**, and **Prisma**. The application combines a public marketing site with an authenticated creator dashboard for managing projects, skills, career entries, certificates, newsletters, and inbound contacts. Email workflows, analytics, and granular content preferences are supported out of the box.
+A production-ready personal portfolio and creator operations platform built with **Next.js 15**, **TypeScript**, and **Prisma**. The application delivers a polished public marketing site backed by an authenticated dashboard that manages projects, skills, certificates, career entries, newsletters, analytics, and inbound contact workflows. Email automation, granular subscription preferences, and engagement features (comments, reactions, and community highlights) are implemented end to end.
 
 ## Table of Contents
 
 - [Overview](#overview)
+  - [Public experience](#public-experience)
+  - [Creator dashboard](#creator-dashboard)
 - [Key Features](#key-features)
 - [Technology Stack](#technology-stack)
 - [System Architecture](#system-architecture)
@@ -13,9 +15,11 @@ A full-stack personal portfolio and content management platform built with **Nex
   - [Installation](#installation)
   - [Environment Variables](#environment-variables)
   - [Database Setup](#database-setup)
+  - [Optional: Seed Sample Content](#optional-seed-sample-content)
   - [Running the App](#running-the-app)
 - [Quality Assurance](#quality-assurance)
 - [Project Structure](#project-structure)
+- [Feature Highlights](#feature-highlights)
 - [API & Integrations](#api--integrations)
 - [Email & Newsletter Workflows](#email--newsletter-workflows)
 - [Analytics & Logging](#analytics--logging)
@@ -26,172 +30,224 @@ A full-stack personal portfolio and content management platform built with **Nex
 
 ## Overview
 
-The portfolio platform serves as both a public-facing site and a creator control panel:
+The platform combines a story-driven marketing site with operational tooling for keeping portfolio content fresh.
 
-- Visitors can explore projects, read the about page, send contact messages, and manage newsletter subscriptions.
-- Authenticated administrators can curate portfolio content, respond to messages, configure email delivery, and trigger newsletter campaigns from a responsive dashboard experience.
+### Public experience
 
-The codebase embraces modern Next.js conventions (App Router, Server Actions, React Server Components) while retaining client-driven interactivity where required for the dashboard UI.
+- **Homepage hero (`app/page.tsx`)** – Animated hero visualization, impact metrics sourced from engagement data, and clear call-to-actions.
+- **About, projects, and skill highlights (`app/about`, `app/projects`, `components/featured-projects.tsx`, `components/skills-showcase.tsx`)** – Curated content sourced from the same data as the dashboard.
+- **Contact funnel (`app/contact`)** – Validated form posts to `POST /api/contacts`, triggers administrative notifications, and optionally sends auto replies.
+- **Newsletter preference centre (`app/newsletter`, `app/unsubscribe`)** – Allows visitors to subscribe, confirm, or adjust granular preferences without exposing the dashboard.
+- **Legal and privacy pages (`app/privacy`, `app/impressum`)** – Built-in placeholders for GDPR compliance.
+
+### Creator dashboard
+
+- **Project management (`app/dashboard/projects`)** – Create, edit, and feature projects, attach technology stacks, feature breakdowns, and upload media via the authenticated upload endpoint.
+- **Skills, certificates, and career history (`app/dashboard/skills`, `certificates`, `career`)** – Structured CRUD workflows mirroring the Prisma schema.
+- **Contacts inbox (`app/dashboard/contacts`)** – Filter inbound messages by status, add notes, and keep a full history of correspondence.
+- **Newsletter operations (`app/dashboard/newsletter`)** – Manage subscribers, craft campaign drafts, schedule sends, and respect per-category preferences defined in `SubscriberPreference`.
+- **Analytics overview (`app/dashboard/analytics`)** – Visualises page views, unique visitors, and contact trends captured via `app/api/analytics/*`.
+- **Settings (`app/dashboard/settings`)** – Configure SMTP, auto-replies, sender identity, and test delivery through `app/api/settings/email`.
 
 ## Key Features
 
-- **Authentication & Access Control**: Credentials-based sign-in powered by NextAuth with JWT sessions and middleware-protected dashboard routes.
-- **Portfolio Management**: CRUD flows for projects, skills, career milestones, and certificates with image support, feature tagging, and optional newsletter promotion.
-- **Contacts Inbox**: Capture messages from the public contact form, categorize them by status, add private notes, and trigger automated replies.
-- **Newsletter Engine**: Manage subscribers, granular subscription preferences, and send project or announcement campaigns using templated transactional emails.
-- **Analytics & Insights**: Track page views and aggregate visitor metrics for dashboard reporting.
-- **Themeable UI**: Tailwind CSS, Radix UI primitives, and Zustand state management deliver a polished, accessible design system with dark mode support.
-- **Developer Tooling**: Strict TypeScript, ESLint, Prettier, and Prisma integration provide a reliable foundation for iterative enhancements.
+- **Authentication & user management** – Credentials-based sign-in powered by NextAuth (`app/api/auth/[...nextauth]/route.ts`) with username management, profile editing, and secure password updates under `app/api/user/*`.
+- **Portfolio content system** – Prisma models in `prisma/schema.prisma` back projects, features, skills, certificates, and career entries. Dashboard forms enforce validation and reuse shared UI primitives.
+- **Engagement tooling** – Visitors can leave comments and reactions on projects (`app/api/projects/[id]/comments|reactions`), while the homepage aggregates community highlights via `lib/engagement.ts`.
+- **Contact workflows** – Contact form submissions are persisted (`Contact` model), automatically notify administrators via `lib/email.ts`, and support status tracking (`unread`, `read`, `replied`, `archived`).
+- **Newsletter engine** – Subscription management, preference toggles, and campaign delivery are handled by `lib/newsletter.ts` and `app/api/newsletter/*`, with unsubscribe tokens and dynamic content linking.
+- **Media management** – Authenticated users can upload images through `app/api/upload/route.ts`, which validates MIME types, stores files in `public/uploads`, and records metadata in the `Media` table.
+- **Analytics & privacy** – Lightweight client tracking (`lib/track-pageview.ts`) respects user consent, hashes IP addresses with `IP_HASH_SALT`, and exposes dashboards through `app/api/analytics`.
+- **Operational logging** – Client-side logs can be forwarded to `app/api/logger/route.ts`, writing to Winston transports configured in `lib/logger.ts`.
 
 ## Technology Stack
 
-| Layer                 | Technologies                                             |
-| --------------------- | -------------------------------------------------------- |
-| Framework             | Next.js 15 (App Router), React 18                        |
-| Language              | TypeScript                                               |
-| Styling               | Tailwind CSS, tailwind-merge, tailwindcss-animate        |
-| UI Components         | Radix UI, Lucide Icons, Embla Carousel                   |
-| State & Forms         | Zustand, React Hook Form, Zod                            |
-| Authentication        | NextAuth (Credentials provider)                          |
-| Email & Notifications | Nodemailer, custom newsletter templates, Sonner toasts   |
-| Data & Persistence    | Prisma ORM targeting MySQL, SWR for client data fetching |
-| Tooling               | pnpm, ESLint, Prettier, TypeScript, Winston logger       |
+| Layer | Technologies |
+| --- | --- |
+| Framework | Next.js 15 (App Router), React 18 |
+| Language | TypeScript, modern ECMAScript |
+| Styling | Tailwind CSS, tailwind-merge, tailwindcss-animate |
+| UI & motion | Radix UI primitives, Framer Motion, React Resizable Panels, Sonner toasts |
+| 3D & visuals | React Three Fiber, @react-three/drei for interactive hero scenes |
+| Forms & state | React Hook Form, Zod validation, Zustand stores |
+| Authentication | NextAuth (credentials provider) with JWT sessions |
+| Data & persistence | Prisma ORM targeting MySQL, SWR for client-side revalidation |
+| Email & notifications | Nodemailer with SMTP credentials persisted via Prisma, Ethereal fallback for development |
+| Telemetry & logging | Custom analytics endpoints, Winston logger, hashed visitor identifiers |
+| Tooling | pnpm, TypeScript strict mode, ESLint 9, Prettier 3 |
 
 ## System Architecture
 
-- **App Router** organizes both public pages (`app/page.tsx`, `app/about`, `app/projects`, etc.) and authenticated dashboard routes (`app/dashboard/...`).
-- **API Routes** in `app/api/*` handle authentication, CRUD operations, analytics logging, newsletter delivery, contact workflows, and configuration endpoints.
-- **Prisma ORM** provides database access with strongly-typed models defined in `prisma/schema.prisma`.
-- **Email services** leverage Nodemailer to send transactional and marketing emails with configurable SMTP providers or Ethereal test credentials.
-- **Client State** uses React Query-like patterns via SWR and lightweight Zustand stores for UI state coordination inside dashboard components.
+- **App Router** structure under `app/` combines public routes, authenticated dashboard segments, nested layouts, and API route handlers.
+- **Prisma ORM** defines schema and migrations in `prisma/`, generating a single shared client via `lib/db.ts` with development-friendly stubbing when the client is missing.
+- **Domain libraries** encapsulate core logic: `lib/auth.ts` (NextAuth configuration), `lib/email.ts` (transport + templates), `lib/newsletter.ts` (campaign orchestration), `lib/engagement.ts` (comments/reactions aggregation), and `lib/track-pageview.ts` (analytics ingestion helper).
+- **Type-safe contracts** live in `types/`, keeping API responses consistent across server actions and client hooks.
+- **Dashboard UI** reuses composable components in `components/dashboard/*`, `components/ui/*`, and custom hooks from `hooks/` (e.g., SWR data fetchers for CRUD resources).
 
 ## Getting Started
 
 ### Prerequisites
 
-- Node.js **>= 18.18.0**
-- pnpm **>= 9.0.0** (or use `corepack enable` to activate the bundled pnpm)
-- A MySQL-compatible database (local Docker, managed service, or PlanetScale)
+- **Node.js** ≥ 18.18.0
+- **pnpm** ≥ 9.0.0 (enable with `corepack enable pnpm` if not installed)
+- **MySQL** 8.x (local instance, Docker container, or managed service such as PlanetScale)
 
 ### Installation
 
 ```bash
--npm install
--npx prisma generate
--npx prisma db push
--npm run build
--npm run start
-+# Clone the repository
-+git clone https://github.com/VectoDE/Portfolio.git
-+cd Portfolio
-+
-+# Install dependencies
-+pnpm install
+# Clone the repository
+git clone https://github.com/VectoDE/Portfolio.git
+cd Portfolio
+
+# Enable pnpm (if required) and install dependencies
+corepack enable pnpm
+pnpm install
 ```
 
 ### Environment Variables
 
-Create a `.env` file at the project root (you can start from `.env.local` in development). The most important variables are outlined below:
+Create a `.env` (or `.env.local`) at the project root. The following variables are consumed throughout the application:
 
-| Variable                                                        | Description                                                                           | Example                                          |
-| --------------------------------------------------------------- | ------------------------------------------------------------------------------------- | ------------------------------------------------ |
-| `DATABASE_URL`                                                  | MySQL connection string used by Prisma. Overrides the default URL in `schema.prisma`. | `mysql://user:password@localhost:3306/portfolio` |
-| `NEXTAUTH_URL`                                                  | Public base URL used by NextAuth during callbacks.                                    | `http://localhost:3000`                          |
-| `NEXTAUTH_SECRET`                                               | Secret key for signing NextAuth JWTs. Generate via `openssl rand -hex 32`.            | `f4d1...`                                        |
-| `NEXT_PUBLIC_APP_URL`                                           | Browser-accessible base URL for links embedded in emails.                             | `http://localhost:3000`                          |
-| `EMAIL_SERVER` / `EMAIL_PORT` / `EMAIL_USER` / `EMAIL_PASSWORD` | SMTP credentials for transactional email delivery.                                    | `smtp.ethereal.email`, `587`, `user`, `pass`     |
-| `EMAIL_FROM`                                                    | Default `from` header for outbound messages.                                          | `Portfolio <noreply@example.com>`                |
-| `ADMIN_EMAIL`                                                   | Administrative notification address for contact form alerts.                          | `admin@example.com`                              |
-| `SEND_AUTO_REPLY`                                               | Enables automatic acknowledgement emails for contact submissions (`true` / `false`).  | `true`                                           |
-| `ETHEREAL_EMAIL` / `ETHEREAL_PASSWORD`                          | Optional Ethereal testing credentials for development previews.                       | `user@ethereal.email`                            |
-| `NEXT_PUBLIC_ENABLE_ANALYTICS`                                  | Toggles client-side page view tracking.                                               | `true`                                           |
+| Variable | Description | Example |
+| --- | --- | --- |
+| `DATABASE_URL` | MySQL connection string consumed by Prisma. Overrides the development default in `prisma/schema.prisma`. | `mysql://user:password@localhost:3306/portfolio` |
+| `NEXTAUTH_URL` | Absolute URL used by NextAuth for callbacks. | `http://localhost:3000` |
+| `NEXTAUTH_SECRET` | Secret used to sign NextAuth JWTs. Generate with `openssl rand -hex 32`. | `f4d1...` |
+| `NEXT_PUBLIC_APP_URL` | Public base URL surfaced in emails and share links. | `http://localhost:3000` |
+| `NEXT_PUBLIC_ENABLE_ANALYTICS` | Enable (`true`) or disable (`false`) client-side page view tracking. | `true` |
+| `NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION` | Optional verification token injected into `<meta name="google-site-verification">`. | `abc123` |
+| `NEXT_PUBLIC_BING_SITE_VERIFICATION` | Optional Bing site verification token exposed as `msvalidate.01`. | `xyz789` |
+| `EMAIL_SERVER`, `EMAIL_PORT`, `EMAIL_USER`, `EMAIL_PASSWORD` | Default SMTP credentials used when no custom settings exist in the dashboard. | `smtp.sendgrid.net`, `587`, `apikey`, `SG...` |
+| `EMAIL_FROM` | Default `From` header if none is stored in `EmailSettings`. | `Portfolio <noreply@example.com>` |
+| `ADMIN_EMAIL` | Default administrative contact for inbound contact alerts. | `admin@example.com` |
+| `SEND_AUTO_REPLY` | Set to `true` to send automatic acknowledgements for contact submissions. | `false` |
+| `ETHEREAL_EMAIL`, `ETHEREAL_PASSWORD` | Optional Ethereal credentials for development previews (fallback transport). | `user@ethereal.email`, `pass` |
+| `IP_HASH_SALT` | Secret salt combined with visitor IPs before hashing analytics records. | `super-secret-salt` |
 
-> **Tip:** Prisma reads `DATABASE_URL` at runtime; ensure it is set before running any Prisma commands.
+> **Tip:** Whenever you introduce a new environment variable, document it in this table and surface an onboarding default inside the relevant API route.
 
 ### Database Setup
 
+1. Adjust `DATABASE_URL` in `.env` (or update the datasource inside `prisma/schema.prisma`) to point at your MySQL instance.
+2. Generate the Prisma client and apply migrations:
+
+   ```bash
+   pnpm prisma:generate
+   pnpm prisma:migrate
+   ```
+
+3. (Optional) Inspect data via Prisma Studio:
+
+   ```bash
+   pnpm prisma:studio
+   ```
+
+### Optional: Seed Sample Content
+
+A helper endpoint exists to populate the database with an admin user and representative content. After running `pnpm dev`, execute:
+
 ```bash
-# Generate the Prisma client after updating the schema
-pnpm prisma:generate
-
-# Apply schema changes to your development database
-pnpm prisma:migrate
-
-# (Optional) Inspect data and edit records in a browser
-pnpm prisma:studio
+curl -X POST http://localhost:3000/api/seed
 ```
+
+The seeding script creates an `admin@example.com` user (password `password123`) alongside demo projects, certificates, skills, and career entries.
 
 ### Running the App
 
-- **Development:** `pnpm dev` (served at `http://localhost:3000`).
-- **Production build:**
+- **Development** – `pnpm dev` (serves the app at `http://localhost:3000`).
+- **Production build** –
   ```bash
   pnpm build
-  pnpm start # listens on port 3020 by default
+  pnpm start   # serves the compiled build on port 3020
   ```
-- **Deploy-ready start:** Use `pnpm prod:start` to run the compiled build on the framework's default port.
+- **Default port start** – `pnpm prod:start` runs the compiled build on the framework’s default port (useful for hosting providers).
 
-Ensure the `.env` file (or environment variables in your hosting provider) is available in both build and runtime environments.
+Ensure `.env` variables are available during both build and runtime. Configure SMTP connectivity before sending newsletters from production.
 
 ## Quality Assurance
 
-- `pnpm lint` – run ESLint against the project.
-- `pnpm typecheck` – execute TypeScript in `--noEmit` mode to validate types.
-- `pnpm format:check` / `pnpm format` – enforce Prettier formatting standards.
-- `pnpm validate` – convenience script that chains linting and type checking.
+Run these scripts locally before pushing changes:
 
-Running these scripts before committing helps keep the codebase consistent and prevents CI failures.
+- `pnpm lint` – ESLint with Next.js rules.
+- `pnpm lint:fix` – Auto-fix lint violations where possible.
+- `pnpm typecheck` – TypeScript in `--noEmit` mode.
+- `pnpm format:check` / `pnpm format` – Enforce Prettier style guidelines.
+- `pnpm validate` – Convenience script chaining linting and type checks.
 
 ## Project Structure
 
 ```
-app/                 # App Router pages, layouts, and API routes
-components/          # Reusable UI components and design system primitives
-hooks/               # Custom React hooks shared across the app
-lib/                 # Utility libraries (auth, database client, logging, emails, analytics)
-prisma/              # Prisma schema and migrations
-public/              # Static assets (images, fonts, icons)
-styles/              # Global CSS and Tailwind configurations
-types/               # Shared TypeScript type definitions
+app/                     # App Router pages, layouts, and API routes
+  about/                 # Public about page content
+  account/               # Authenticated profile & settings pages
+  contact/               # Public contact form flow
+  dashboard/             # Creator dashboard (analytics, CRUD, newsletters, settings)
+  newsletter/            # Subscriber management & preference centre
+  unsubscribe/           # Opt-out and token validation flows
+  api/                   # REST-like endpoints backing dashboard actions and public forms
+components/              # Reusable UI primitives and feature components
+  dashboard/             # Dashboard-specific tables, forms, charts, and modals
+  ui/                    # Design system components built on Radix + Tailwind
+hooks/                   # Client-side SWR data hooks for CRUD resources
+lib/                     # Authentication, database, email, analytics, logging helpers
+prisma/                  # Prisma schema and migrations
+public/uploads/          # Runtime media uploads stored by the upload API
+styles/                  # Tailwind and global CSS configuration
+types/                   # Shared TypeScript types and API response contracts
 ```
+
+## Feature Highlights
+
+- **Dashboard charts & metrics** – Analytics widgets pull from `app/api/analytics/route.ts` and `app/api/analytics/pageview/route.ts`, summarising page views, unique visitors, and contact trends.
+- **Content moderation** – Project feedback surfaces in `components/project-feedback.tsx`, with mutation endpoints handling optimistic updates and SWR cache invalidation.
+- **Email settings management** – Administrators can persist SMTP credentials and toggle auto-replies via `app/dashboard/settings/email-form.tsx`, backed by Prisma records in `EmailSettings`.
+- **Community highlights** – `lib/engagement.ts` aggregates top projects, comment counts, and reactions, powering homepage storytelling.
 
 ## API & Integrations
 
-- `app/api/auth/*` – NextAuth handlers for credentials-based login and session management.
-- `app/api/projects`, `app/api/skills`, `app/api/certificates`, `app/api/career` – CRUD endpoints for dashboard resources.
-- `app/api/contacts` – Submit and manage inbound contact messages; supports automated replies.
-- `app/api/newsletter/*` – Subscriber management, campaign scheduling, and delivery.
-- `app/api/analytics` & `app/api/logger` – Capture page views and persist structured logs.
-- `app/api/upload` – Handle media uploads from the dashboard.
+Key route handlers live under `app/api/*`:
 
-Each route enforces authentication and input validation where appropriate using Zod schemas and middleware guards.
+- `auth/[...nextauth]` – NextAuth credentials provider & JWT session management.
+- `register` & `login` flows – User onboarding and sign-in endpoints.
+- `user/profile`, `user/password` – Profile updates, username validation, and password resets.
+- `projects`, `skills`, `certificates`, `career` – CRUD endpoints with Zod validation and SWR-compatible responses.
+- `projects/[id]/comments` & `projects/[id]/reactions` – Feedback capture with authentication checks and reaction toggling.
+- `contacts` – Public form ingestion plus authenticated pagination and status filters.
+- `newsletter/*` – Subscriber CRUD, campaign scheduling, send triggers, and unsubscribe helpers.
+- `analytics/*` – Page view tracking, aggregated metrics, and contact funnel reporting.
+- `settings/email` – Persisted SMTP configuration and test-delivery utilities.
+- `upload` – Authenticated media uploads with MIME/size guards and filesystem persistence.
+- `logger` – Client log forwarding to the Winston-based server logger.
+
+All endpoints enforce authentication where appropriate, validate inputs with Zod or manual guards, and surface descriptive error messages.
 
 ## Email & Newsletter Workflows
 
-- SMTP credentials are configurable from the dashboard settings and persisted in the `EmailSettings` model.
-- Newsletters support personalized unsubscribe links and category-based preferences (projects, certificates, skills, careers).
-- Development mode supports Ethereal email previews with logged message URLs.
+- SMTP credentials are securely stored in the `EmailSettings` table and can be updated from the dashboard. If unset, defaults from environment variables (or Ethereal in development) are used.
+- Campaigns created in `app/dashboard/newsletter` leverage helpers in `lib/newsletter.ts` to build personalised unsubscribe links (`/unsubscribe?token=…`) and respect category preferences.
+- Contact form submissions trigger `sendContactNotification` and, when enabled, `sendContactAutoReply`, keeping stakeholders informed without manual intervention.
 
 ## Analytics & Logging
 
-- Client-side tracking uses a lightweight page view reporter controlled via `NEXT_PUBLIC_ENABLE_ANALYTICS`.
-- Server-side analytics aggregates visits (`Analytics`, `PageView` models) for charting in the dashboard.
-- Structured logging is handled by a Winston logger with environment-aware transports.
+- `lib/track-pageview.ts` sends anonymised page view events to `POST /api/analytics/pageview`, hashing IP addresses with `IP_HASH_SALT` to protect visitor privacy.
+- Aggregated metrics (totals, unique visitors, time windows) are exposed via `GET /api/analytics/pageview` and rendered in dashboard charts.
+- The Winston logger in `lib/logger.ts` writes to rotating files under `logs/` and to the console during development. Client-originated logs can be forwarded to the `logger` API for investigation.
 
 ## Deployment Notes
 
-- Provide production-ready values for `NEXTAUTH_URL`, `NEXTAUTH_SECRET`, SMTP credentials, and `NEXT_PUBLIC_APP_URL` before deploying.
-- Ensure your hosting platform exposes the `DATABASE_URL` to Prisma during both build and runtime phases.
-- If using a managed MySQL provider, update `prisma/schema.prisma` or set `DATABASE_URL` accordingly before running migrations in CI/CD pipelines.
-- Use `pnpm build` followed by `pnpm start` (or your platform's adapter) to serve the optimized production bundle.
+- Set production values for `NEXTAUTH_URL`, `NEXTAUTH_SECRET`, `NEXT_PUBLIC_APP_URL`, SMTP credentials, and `IP_HASH_SALT` before deploying.
+- Ensure the hosting platform exposes `DATABASE_URL` during both build and runtime so Prisma migrations and the client can connect.
+- Persist the `logs/` directory (or redirect logs to your hosting provider’s logging solution) if you rely on on-disk Winston transports.
+- Back up the `public/uploads/` directory or replace the upload implementation with object storage when deploying to stateless environments.
+- Use `pnpm build` + `pnpm start` (or `pnpm prod:start`) to serve the optimised production bundle. Configure process managers or hosting adapters accordingly.
 
 ## Security
 
-Please review [SECURITY.md](./SECURITY.md) for vulnerability disclosure guidelines and supported release information.
+Review the dedicated [SECURITY.md](./SECURITY.md) for supported versions, disclosure policy, hardening tips, and compliance posture. Highlights include hashed analytics identifiers, role-based dashboard access, and guarded upload endpoints.
 
 ## Contributing
 
-We welcome improvements and bug fixes! See [CONTRIBUTING.md](./CONTRIBUTING.md) for development workflows, coding standards, and pull request expectations.
+Contributions are welcome! See [CONTRIBUTING.md](./CONTRIBUTING.md) for branching strategy, coding standards, database migration expectations, and review etiquette.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,67 +1,77 @@
 # Security Policy
 
+We are committed to protecting users of the Portfolio platform and appreciate responsible disclosures that help keep the project safe.
+
 ## Supported Versions
 
-Security fixes are applied to the latest commit on the `main` branch. Downstream forks or tagged releases should regularly merge from `main` to receive updates.
+Security fixes target the latest commit on the `main` branch. Downstream forks or tagged releases should regularly merge `main` to receive updates.
 
-| Version                          | Supported           |
-| -------------------------------- | ------------------- |
-| `main`                           | ✅                  |
-| Tagged releases prior to `1.0.0` | ⚠️ Best-effort only |
+| Version | Supported |
+| --- | --- |
+| `main` | ✅ |
+| Tagged releases prior to `1.0.0` | ⚠️ Best effort |
 
 ## Reporting a Vulnerability
 
-We take security vulnerabilities seriously. If you discover a vulnerability, please use one of the following private channels:
+Please report vulnerabilities through one of the following private channels:
 
-1. **GitHub Private Vulnerability Reporting** – Use the "Report a vulnerability" button on the repository's **Security** tab to open a confidential advisory.
-2. **Direct Contact** – If private vulnerability reporting is unavailable for you, reach out to the maintainers through the contact information listed on their GitHub profile. Please use the subject line "[Portfolio] Vulnerability Disclosure".
+1. **GitHub Private Vulnerability Reporting** – Use the “Report a vulnerability” button on the repository’s **Security** tab to open a confidential advisory.
+2. **Direct Contact** – If the GitHub channel is unavailable, contact the maintainers through the email address listed on their profile. Use the subject line `'[Portfolio] Vulnerability Disclosure'`.
 
-When reporting, please include:
+When reporting, include:
 
 - A concise description of the issue and potential impact.
 - Steps to reproduce or proof-of-concept code.
-- Any suggested mitigations.
-- Your availability for follow-up questions.
+- Affected routes, environment prerequisites, and any relevant logs.
+- Suggested mitigations or temporary workarounds.
+- Preferred contact information for follow-up.
 
-Please do **not** create public issues or pull requests that disclose the vulnerability before we have a fix in place.
+Do **not** open public issues or pull requests containing sensitive details before a fix is coordinated.
 
 ## What to Expect
 
-- **Acknowledgement**: We aim to acknowledge receipt within **3 business days**.
-- **Assessment**: Issues are triaged for severity and reproducibility. We may contact you for additional context or testing details.
-- **Remediation**: Once a fix is developed, we will coordinate disclosure timing with you. Critical vulnerabilities are addressed with the highest priority.
-- **Credit**: With your consent, we are happy to credit reporters in release notes or advisories after a fix has shipped.
+- **Acknowledgement** – We aim to acknowledge new reports within **3 business days**.
+- **Assessment** – Issues are triaged for severity and reproducibility. We may request additional context or testing details.
+- **Remediation** – Critical vulnerabilities are prioritised. When a fix is ready, we will coordinate a disclosure timeline with you.
+- **Credit** – With your permission, we are happy to credit reporters in release notes or advisories.
 
 ## Scope
 
 This policy covers the code and configurations maintained in this repository, including:
 
 - Next.js application code (`app`, `components`, `hooks`, `lib`, `types`).
-- API routes and server-side logic.
-- Database schema definitions under `prisma/`.
+- API routes, server actions, and background jobs.
+- Database schema and migrations under `prisma/`.
 - Build tooling and configuration files that ship with the project.
 
-Third-party services (e.g., hosting platforms, SMTP providers, analytics vendors) are out of scope; please contact those providers directly.
+Third-party services (hosting, SMTP providers, analytics vendors, etc.) are out of scope. Please report their issues directly to the relevant provider.
 
-## Security Best Practices
+## Data Handling & Privacy
 
-If you deploy or extend this project, consider the following hardening steps:
+- Visitor analytics (`PageView`, `Analytics`) hash IP addresses with `IP_HASH_SALT` before persistence to limit personal data exposure.
+- Contact form submissions store names, emails, and messages for follow-up. Administrators should purge or anonymise old messages according to their compliance obligations.
+- Uploaded media is stored on disk at `public/uploads/`. Restrict filesystem permissions in production and prefer object storage for long-term deployments.
+- Email settings and credentials are persisted in `EmailSettings`. Rotate secrets regularly and restrict database access.
 
-- Configure strong `NEXTAUTH_SECRET` and rotate credentials regularly.
-- Restrict database access with least-privilege accounts and TLS connections.
-- Limit dashboard access behind HTTPS and trusted identity providers.
-- Monitor dependency updates and run `pnpm update` / `pnpm audit` on a regular cadence.
-- Enable rate limiting and CAPTCHA on public forms if exposing the site to production traffic.
+## Hardening Checklist
 
-## Compliance with Industry Standards
+Before deploying to production, review the following safeguards:
 
-- **OWASP Top 10** – Security controls and testing procedures are aligned with the OWASP Top 10 categories to mitigate the most
-  prevalent web application risks.
-- **ISO/IEC 27001** – Operational processes are designed to integrate into an Information Security Management System (ISMS)
-  consistent with ISO/IEC 27001, including regular risk assessments, documented controls, and continuous improvement loops.
-- **BSI IT-Grundschutz** – Technical and organizational safeguards take guidance from the BSI IT-Grundschutz catalogs to
-  achieve an appropriate level of protection for confidentiality, integrity, and availability.
-- **NIS-2 / IT-Sicherheitsgesetz** – Incident response and notification processes meet the requirements of the German
-  IT-Sicherheitsgesetz and the EU NIS-2 directive for rapid detection, reporting, and remediation of significant events.
+- Generate strong values for `NEXTAUTH_SECRET`, `IP_HASH_SALT`, SMTP credentials, and database passwords. Store them securely.
+- Serve all traffic over HTTPS and configure trusted reverse proxies so `x-forwarded-for` headers are reliable.
+- Limit dashboard access to trusted operators. Consider additional identity providers or IP allowlists when possible.
+- Enable rate limiting and CAPTCHA or similar protections on the public contact form if exposed to untrusted traffic.
+- Regularly update dependencies (`pnpm update`, `pnpm audit`) and apply Prisma migrations promptly.
+- Monitor `logs/` for suspicious activity and forward logs to a central logging solution when available.
+
+## Compliance Alignment
+
+- **OWASP Top 10** – Input validation, authentication, and session handling follow OWASP recommendations.
+- **ISO/IEC 27001** – Development practices (change control, least privilege) are designed to slot into an ISMS aligned with ISO/IEC 27001.
+- **BSI IT-Grundschutz & NIS-2** – Incident response expectations and notification cadences align with European regulatory guidance, including Germany’s IT-Sicherheitsgesetz.
+
+## Responsible Disclosure Recognition
+
+We appreciate the time and effort required to investigate potential vulnerabilities. With your consent, we will acknowledge responsible reporters in release notes or a dedicated hall of fame once a fix is shipped.
 
 Thank you for helping us keep the Portfolio platform secure.


### PR DESCRIPTION
## Summary
- expand the README with up-to-date feature descriptions, environment setup, and operational guidance
- enhance the contributing guide with environment bootstrapping, testing requirements, and notification testing notes
- update the security policy with current hardening advice, data handling practices, and disclosure workflow details

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_69051cf8e540832ca7a1f10e6afd91c5