### PR TITLE
Add environment template and CI workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,28 @@
+# Core application URLs
+NEXT_PUBLIC_APP_URL="http://localhost:3000"
+NEXTAUTH_URL="http://localhost:3000"
+
+# Authentication
+NEXTAUTH_SECRET="replace-with-a-secure-random-string"
+
+# Database
+DATABASE_URL="mysql://USER:PASSWORD@HOST:3306/DATABASE"
+
+# Email defaults (used when no custom settings are stored)
+EMAIL_SERVER="smtp.example.com"
+EMAIL_PORT="587"
+EMAIL_USER="apikey"
+EMAIL_PASSWORD="replace-with-smtp-password"
+EMAIL_FROM="Portfolio <noreply@example.com>"
+ADMIN_EMAIL="admin@example.com"
+SEND_AUTO_REPLY="false"
+
+# Development SMTP fallbacks (Ethereal)
+ETHEREAL_EMAIL=""
+ETHEREAL_PASSWORD=""
+
+# Analytics and verification
+NEXT_PUBLIC_ENABLE_ANALYTICS="false"
+NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION=""
+NEXT_PUBLIC_BING_SITE_VERIFICATION=""
+IP_HASH_SALT="replace-with-random-salt"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Lint, typecheck, and build
+    runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: mysql://user:password@localhost:3306/portfolio
+      NEXTAUTH_SECRET: test-secret
+      NEXTAUTH_URL: http://localhost:3000
+      NEXT_PUBLIC_APP_URL: http://localhost:3000
+      NEXT_PUBLIC_ENABLE_ANALYTICS: "false"
+      NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION: ""
+      NEXT_PUBLIC_BING_SITE_VERIFICATION: ""
+      EMAIL_SERVER: smtp.example.com
+      EMAIL_PORT: "587"
+      EMAIL_USER: apikey
+      EMAIL_PASSWORD: smtp-password
+      EMAIL_FROM: Portfolio <noreply@example.com>
+      ADMIN_EMAIL: admin@example.com
+      SEND_AUTO_REPLY: "false"
+      ETHEREAL_EMAIL: user@example.com
+      ETHEREAL_PASSWORD: password
+      IP_HASH_SALT: ci-test-salt
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.13.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm prisma:generate
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Type check
+        run: pnpm typecheck
+
+      - name: Build
+        run: pnpm build

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ yarn-error.log*
 # env files
 .env
 .env.*
+!.env.example
 medium-private-key.pem
 
 # vercel


### PR DESCRIPTION
## Summary
- add a checked-in `.env.example` covering all environment variables referenced by the application
- configure a pnpm-based CI workflow that lints, type-checks, and builds the project on pushes and pull requests
- allow committing the environment example file by updating `.gitignore`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6905e8e4f564832ca1f840351f61e65e