### PR TITLE
Tune Prisma schema for MySQL text compatibility

### DIFF
--- a/app/api/analytics/contacts/route.ts
+++ b/app/api/analytics/contacts/route.ts
@@ -60,20 +60,22 @@ export async function GET(req: Request) {
         : Math.round((change / previousPeriodCount) * 100)
 
     // Get status breakdown
-    const statusBreakdownRaw = await prisma.$queryRaw<Array<{ status: string; count: bigint }>>`
-      SELECT status, COUNT(*) as count
-      FROM "Contact"
-      GROUP BY status
-      ORDER BY count DESC
-    `
-
-    // Convert BigInt to Number to avoid serialization issues
-    const statusBreakdown = statusBreakdownRaw.map(
-      ({ status, count }: { status: string; count: bigint }) => ({
-        status,
-        count: Number(count),
-      }),
-    )
+    const statusBreakdown = await prisma.contact
+      .groupBy({
+        by: ["status"],
+        _count: { _all: true },
+        orderBy: {
+          _count: {
+            _all: "desc",
+          },
+        },
+      })
+      .then((rows) =>
+        rows.map(({ status, _count }) => ({
+          status,
+          count: _count._all,
+        })),
+      )
 
     // Get daily contacts for the period
     const dailyContacts: { date: string; count: number }[] = []

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -41,7 +41,7 @@ model Project {
   logoUrl            String?          @db.Text
   githubUrl          String?          @db.Text
   featured           Boolean          @default(false)
-  developmentProcess String?          @db.Text @default("This project was developed using an agile methodology, with regular iterations and feedback cycles.")
+  developmentProcess String?          @db.Text
   challengesFaced    String?          @db.Text
   futurePlans        String?          @db.Text
   logContent         String?          @db.Text

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,7 +17,7 @@ model User {
   password      String
   name          String?
   username      String?
-  imageUrl      String?
+  imageUrl      String?               @db.Text
   role          String?               @default("Member")
   createdAt     DateTime              @default(now())
   updatedAt     DateTime              @updatedAt
@@ -34,17 +34,17 @@ model User {
 model Project {
   id                 String           @id @default(cuid())
   title              String
-  description        String
-  technologies       String
-  link               String?
-  imageUrl           String?
-  logoUrl            String?
-  githubUrl          String?
+  description        String           @db.Text
+  technologies       String           @db.Text
+  link               String?          @db.Text
+  imageUrl           String?          @db.Text
+  logoUrl            String?          @db.Text
+  githubUrl          String?          @db.Text
   featured           Boolean          @default(false)
-  developmentProcess String?          @default("This project was developed using an agile methodology, with regular iterations and feedback cycles.")
-  challengesFaced    String?
-  futurePlans        String?
-  logContent         String?
+  developmentProcess String?          @db.Text @default("This project was developed using an agile methodology, with regular iterations and feedback cycles.")
+  challengesFaced    String?          @db.Text
+  futurePlans        String?          @db.Text
+  logContent         String?          @db.Text
   createdAt          DateTime         @default(now())
   updatedAt          DateTime         @updatedAt
   userId             String
@@ -58,7 +58,7 @@ model Project {
 model ProjectFeature {
   id          String   @id @default(cuid())
   name        String
-  description String?
+  description String?  @db.Text
   projectId   String
   project     Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
   createdAt   DateTime @default(now())
@@ -70,8 +70,8 @@ model Certificate {
   name      String
   issuer    String
   date      DateTime
-  link      String?
-  imageUrl  String?
+  link      String?  @db.Text
+  imageUrl  String?  @db.Text
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   userId    String
@@ -97,8 +97,8 @@ model Career {
   company     String
   startDate   DateTime
   endDate     String?
-  description String
-  logoUrl     String?
+  description String   @db.Text
+  logoUrl     String?  @db.Text
   location    String?
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
@@ -111,19 +111,19 @@ model Contact {
   name      String
   email     String
   subject   String?
-  message   String
+  message   String   @db.Text
   status    String   @default("unread") // unread, read, replied, archived
-  notes     String?
+  notes     String?  @db.Text
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }
 
 model PageView {
   id        String   @id @default(cuid())
-  path      String
-  ipAddress String?
-  userAgent String?
-  referrer  String?
+  path      String   @db.VarChar(512)
+  ipAddress String?  @db.VarChar(64)
+  userAgent String?  @db.Text
+  referrer  String?  @db.Text
   createdAt DateTime @default(now())
 }
 
@@ -177,7 +177,7 @@ model SubscriberPreference {
 model Newsletter {
   id           String    @id @default(cuid())
   subject      String
-  content      String
+  content      String    @db.Text
   sentAt       DateTime?
   scheduledFor DateTime?
   status       String    @default("draft") // draft, scheduled, sent, cancelled
@@ -208,7 +208,7 @@ model Media {
   fileName     String
   mimeType     String?
   size         Int
-  url          String
+  url          String   @db.Text
   createdAt    DateTime @default(now())
 }
 
@@ -224,7 +224,7 @@ model ProjectComment {
   project   Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
   userId    String
   user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  content   String
+  content   String   @db.Text
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }


### PR DESCRIPTION
## Summary
- mark long-form content and URL fields as MySQL text columns to avoid varchar length limits
- size page view identifiers for hashed IPs and longer paths while keeping analytics queries compatible
- ensure user media fields use text storage so Prisma can operate without MySQL truncation errors

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_6906167e351c832ca18430d4075c1743