### PR TITLE
Fix dashboard analytics grouping and improve account layout

### DIFF
--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -11,6 +11,8 @@ import { Badge } from "@/components/ui/badge"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import prisma from "@/lib/db"
 import { authOptions } from "@/lib/auth"
+import { MainNav } from "@/components/main-nav"
+import { SiteFooter } from "@/components/site-footer"
 
 export const metadata: Metadata = {
   title: "Your account",
@@ -186,10 +188,12 @@ export default async function AccountPage() {
   return (
     <div className="relative min-h-screen overflow-hidden">
       <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(76,29,149,0.35),_transparent_55%)]" />
-      <div className="relative z-10">
-        <div className="mx-auto flex w-full max-w-6xl flex-col gap-10 px-4 py-16 sm:px-6 lg:px-8">
-          <AnimatedSection className="rounded-3xl border border-white/10 bg-background/70 p-8 shadow-xl backdrop-blur">
-            <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+      <div className="relative z-10 flex min-h-screen flex-col">
+        <MainNav />
+        <main className="flex-1">
+          <div className="mx-auto flex w-full max-w-6xl flex-col gap-10 px-4 py-16 sm:px-6 lg:px-8">
+            <AnimatedSection className="rounded-3xl border border-white/10 bg-background/70 p-8 shadow-xl backdrop-blur">
+              <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
               <div className="flex items-center gap-6">
                 <Avatar className="h-20 w-20 border border-primary/40">
                   <AvatarImage src={user.imageUrl ?? undefined} alt={user.name ?? "Account avatar"} />
@@ -363,7 +367,9 @@ export default async function AccountPage() {
               </div>
             )}
           </AnimatedSection>
-        </div>
+          </div>
+        </main>
+        <SiteFooter />
       </div>
     </div>
   )

--- a/app/api/analytics/contacts/route.ts
+++ b/app/api/analytics/contacts/route.ts
@@ -60,12 +60,12 @@ export async function GET(req: Request) {
         : Math.round((change / previousPeriodCount) * 100)
 
     // Get status breakdown
-    const statusBreakdownRows: { status: string; _count: { _all: number } }[] = await prisma.contact.groupBy({
+    const statusBreakdownRows: { status: string; _count: { _all: number; status: number } }[] = await prisma.contact.groupBy({
       by: ["status"],
-      _count: { _all: true },
+      _count: { _all: true, status: true },
       orderBy: {
         _count: {
-          _all: "desc",
+          status: "desc",
         },
       },
     })

--- a/app/api/analytics/route.ts
+++ b/app/api/analytics/route.ts
@@ -284,7 +284,7 @@ async function getPageViewAnalytics(days = 30) {
   const dailyViews = await getDailyData("", "pageview", days)
 
   // Get top pages
-  const topPagesRaw: { path: string | null; _count: { _all: number } }[] = await prisma.pageView.groupBy({
+  const topPagesRaw: { path: string | null; _count: { _all: number; path: number } }[] = await prisma.pageView.groupBy({
     by: ["path"],
     where: {
       createdAt: {
@@ -292,10 +292,10 @@ async function getPageViewAnalytics(days = 30) {
         lte: periodEndDate,
       },
     },
-    _count: { _all: true },
+    _count: { _all: true, path: true },
     orderBy: {
       _count: {
-        _all: "desc",
+        path: "desc",
       },
     },
     take: 5,

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -230,10 +230,10 @@ async function getStats() {
     prisma.contact
       .groupBy({
         by: ["status"],
-        _count: { _all: true },
+        _count: { _all: true, status: true },
         orderBy: {
           _count: {
-            _all: "desc",
+            status: "desc",
           },
         },
       })

--- a/components/account-profile-form.tsx
+++ b/components/account-profile-form.tsx
@@ -10,6 +10,7 @@ import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/componen
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { useToast } from "@/components/ui/use-toast"
+import { FileUpload } from "@/components/file-upload"
 
 interface AccountProfileFormProps {
   user: {
@@ -143,8 +144,14 @@ export function AccountProfileForm({ user }: AccountProfileFormProps) {
               Usernames are optional but help others mention you in discussions.
             </p>
           </div>
+          <FileUpload
+            id="avatar"
+            label="Upload avatar image"
+            value={imageUrl}
+            onChange={(value) => setImageUrl(value)}
+          />
           <div className="grid gap-2">
-            <Label htmlFor="imageUrl">Avatar image URL</Label>
+            <Label htmlFor="imageUrl">Or use an external image URL</Label>
             <Input
               id="imageUrl"
               value={imageUrl}


### PR DESCRIPTION
## Summary
- adjust Prisma groupBy aggregations to avoid invalid _all ordering and keep analytics sorting
- add main navigation and footer to the account page for consistency with the rest of the site
- enhance the account profile form with the shared file upload component for avatar updates

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_69062227fa6c832c975937833196f8aa