### PR TITLE
Fix avatar preview and lucide icon selection

### DIFF
--- a/app/dashboard/skills/[id]/page.tsx
+++ b/app/dashboard/skills/[id]/page.tsx
@@ -5,7 +5,7 @@ import type React from "react"
 import { useState, useEffect } from "react"
 import { useRouter } from "next/navigation"
 import Link from "next/link"
-import { ArrowLeft } from "lucide-react"
+import { ArrowLeft, icons } from "lucide-react"
 import * as LucideIcons from "lucide-react"
 
 import { Button } from "@/components/ui/button"
@@ -33,9 +33,9 @@ import { AnimatedSection } from "@/components/animated-section"
 import { AnimatedList } from "@/components/animated-list"
 
 // Get all available Lucide icons
-const iconNames = Object.keys(LucideIcons).filter(
-  (key) => typeof LucideIcons[key as keyof typeof LucideIcons] === "function" && key !== "default",
-)
+const iconNames = Object.keys(icons)
+  .filter((key) => key !== "default")
+  .sort((a, b) => a.localeCompare(b))
 
 interface EditSkillPageProps {
   params: {

--- a/app/dashboard/skills/new/page.tsx
+++ b/app/dashboard/skills/new/page.tsx
@@ -5,9 +5,8 @@ import type React from "react"
 import { useState, useRef, useEffect } from "react"
 import { useRouter } from "next/navigation"
 import Link from "next/link"
-import { ArrowLeft, Search, Upload, X } from "lucide-react"
+import { ArrowLeft, Search, Upload, X, icons } from "lucide-react"
 import Image from "next/image"
-import * as LucideIcons from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -33,13 +32,9 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { IconRenderer } from "@/components/icon-renderer"
 
 // Get icon names but filter out non-component exports
-const iconNames = Object.keys(LucideIcons).filter(
-  (key) =>
-    typeof LucideIcons[key as keyof typeof LucideIcons] === "function" &&
-    key !== "default" &&
-    key !== "icons" &&
-    key !== "createLucideIcon",
-)
+const iconNames = Object.keys(icons)
+  .filter((key) => key !== "default")
+  .sort((a, b) => a.localeCompare(b))
 
 export default function NewSkillPage() {
   const router = useRouter()

--- a/components/account-profile-form.tsx
+++ b/components/account-profile-form.tsx
@@ -64,7 +64,12 @@ export function AccountProfileForm({ user }: AccountProfileFormProps) {
         throw new Error(error.error ?? "Unable to save profile")
       }
 
-      const updatedUser = await response.json()
+      const updatedUser: {
+        id: string
+        name: string | null
+        email: string
+        imageUrl: string | null
+      } = await response.json()
 
       toast({
         title: "Profile updated",
@@ -78,6 +83,8 @@ export function AccountProfileForm({ user }: AccountProfileFormProps) {
             ...session.user,
             name: updatedUser.name,
             email: updatedUser.email,
+            image: updatedUser.imageUrl,
+            imageUrl: updatedUser.imageUrl,
           },
         })
       }

--- a/components/dashboard-nav.tsx
+++ b/components/dashboard-nav.tsx
@@ -93,13 +93,15 @@ export function DashboardNav() {
     }
   }
 
-  const getInitials = (name: string | null | undefined) => {
-    if (!name) return "U"
-    return name
-      .split(" ")
-      .map((n) => n[0])
+  const getInitials = (name: string | null | undefined, email?: string | null) => {
+    const source = name?.trim() || email?.trim() || "User"
+    return source
+      .split(/\s+/)
+      .filter(Boolean)
+      .map((part) => part[0]?.toUpperCase() ?? "")
       .join("")
-      .toUpperCase()
+      .slice(0, 2)
+      .padEnd(1, "U")
   }
 
   return (
@@ -180,10 +182,12 @@ export function DashboardNav() {
                   >
                     <Avatar className="h-8 w-8">
                       <AvatarImage
-                        src={session.user.image || ""}
-                        alt={session.user.name || "User"}
+                        src={session.user.image || session.user.imageUrl || undefined}
+                        alt={session.user.name || session.user.email || "User"}
                       />
-                      <AvatarFallback>{getInitials(session.user.name)}</AvatarFallback>
+                      <AvatarFallback>
+                        {getInitials(session.user.name, session.user.email)}
+                      </AvatarFallback>
                     </Avatar>
                     {!isCollapsed && (
                       <div className="flex flex-col items-start text-left">
@@ -254,8 +258,13 @@ export function DashboardNav() {
               <DropdownMenuTrigger asChild>
                 <Button variant="ghost" size="icon" className="rounded-full p-0">
                   <Avatar className="h-8 w-8">
-                    <AvatarImage src={session.user.image || ""} alt={session.user.name || "User"} />
-                    <AvatarFallback>{getInitials(session.user.name)}</AvatarFallback>
+                    <AvatarImage
+                      src={session.user.image || session.user.imageUrl || undefined}
+                      alt={session.user.name || session.user.email || "User"}
+                    />
+                    <AvatarFallback>
+                      {getInitials(session.user.name, session.user.email)}
+                    </AvatarFallback>
                   </Avatar>
                 </Button>
               </DropdownMenuTrigger>
@@ -299,8 +308,13 @@ export function DashboardNav() {
             {session?.user && (
               <div className="flex items-center gap-3 px-4 py-3 border-b">
                 <Avatar className="h-10 w-10">
-                  <AvatarImage src={session.user.image || ""} alt={session.user.name || "User"} />
-                  <AvatarFallback>{getInitials(session.user.name)}</AvatarFallback>
+                  <AvatarImage
+                    src={session.user.image || session.user.imageUrl || undefined}
+                    alt={session.user.name || session.user.email || "User"}
+                  />
+                  <AvatarFallback>
+                    {getInitials(session.user.name, session.user.email)}
+                  </AvatarFallback>
                 </Avatar>
                 <div className="flex-1">
                   <p className="font-medium">{session.user.name}</p>

--- a/components/file-upload.tsx
+++ b/components/file-upload.tsx
@@ -3,7 +3,6 @@
 import type React from "react"
 
 import { useState, useRef, useEffect } from "react"
-import Image from "next/image"
 import { Upload, X, File } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -133,13 +132,13 @@ export function FileUpload({
 
       <div className="flex flex-col gap-3">
         {isImage && preview && (
-          <div className="relative w-full max-w-[200px] h-[150px] rounded-md overflow-hidden border">
-            <Image
+          <div className="relative h-[150px] w-full max-w-[200px] overflow-hidden rounded-md border">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
               src={preview || "/placeholder.svg"}
               alt="Preview"
-              fill
-              className="object-cover"
-              sizes="200px"
+              className="h-full w-full object-cover"
+              loading="lazy"
             />
             <Button
               type="button"

--- a/components/main-nav.tsx
+++ b/components/main-nav.tsx
@@ -69,13 +69,15 @@ export function MainNav() {
     }
   }
 
-  const getInitials = (name: string | null | undefined) => {
-    if (!name) return "U"
-    return name
-      .split(" ")
-      .map((n) => n[0])
+  const getInitials = (name: string | null | undefined, email?: string | null) => {
+    const source = name?.trim() || email?.trim() || "User"
+    return source
+      .split(/\s+/)
+      .filter(Boolean)
+      .map((part) => part[0]?.toUpperCase() ?? "")
       .join("")
-      .toUpperCase()
+      .slice(0, 2)
+      .padEnd(1, "U")
   }
 
   return (
@@ -138,8 +140,13 @@ export function MainNav() {
               <DropdownMenuTrigger asChild>
                 <Button variant="ghost" size="sm" className="gap-2 hidden md:inline-flex">
                   <Avatar className="h-8 w-8">
-                    <AvatarImage src="" alt={session.user?.name || "User"} />
-                    <AvatarFallback>{getInitials(session.user?.name)}</AvatarFallback>
+                    <AvatarImage
+                      src={session.user?.image || session.user?.imageUrl || undefined}
+                      alt={session.user?.name || session.user?.email || "User"}
+                    />
+                    <AvatarFallback>
+                      {getInitials(session.user?.name, session.user?.email)}
+                    </AvatarFallback>
                   </Avatar>
                   <span className="font-medium">{session.user?.name}</span>
                 </Button>
@@ -245,8 +252,13 @@ export function MainNav() {
                   <>
                     <div className="flex items-center gap-3 py-3 border-t border-b">
                       <Avatar className="h-10 w-10">
-                        <AvatarImage src="" alt={session.user?.name || "User"} />
-                        <AvatarFallback>{getInitials(session.user?.name)}</AvatarFallback>
+                        <AvatarImage
+                          src={session.user?.image || session.user?.imageUrl || undefined}
+                          alt={session.user?.name || session.user?.email || "User"}
+                        />
+                        <AvatarFallback>
+                          {getInitials(session.user?.name, session.user?.email)}
+                        </AvatarFallback>
                       </Avatar>
                       <div>
                         <p className="font-medium">{session.user?.name}</p>

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -38,6 +38,8 @@ export const authOptions: NextAuthOptions = {
           email: user.email,
           name: user.name,
           role: user.role,
+          image: user.imageUrl,
+          imageUrl: user.imageUrl,
         }
       },
     }),
@@ -50,12 +52,20 @@ export const authOptions: NextAuthOptions = {
   },
   callbacks: {
     session: ({ session, token }) => {
+      const imageFromToken = typeof token.image === "string" ? token.image : null
+      const imageUrlFromToken =
+        typeof token.imageUrl === "string"
+          ? token.imageUrl
+          : imageFromToken ?? (typeof session.user?.image === "string" ? session.user.image : null)
+
       return {
         ...session,
         user: {
           ...session.user,
           id: token.id,
           role: token.role,
+          image: imageFromToken,
+          imageUrl: imageUrlFromToken,
         },
       }
     },
@@ -65,6 +75,8 @@ export const authOptions: NextAuthOptions = {
           ...token,
           id: user.id,
           role: user.role,
+          image: (user as { image?: string | null }).image ?? null,
+          imageUrl: (user as { imageUrl?: string | null }).imageUrl ?? null,
         }
       }
       return token

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -9,6 +9,7 @@ declare module "next-auth" {
       /** The user's id. */
       id: string
       role?: string | null
+      imageUrl?: string | null
     } & DefaultSession["user"]
   }
 
@@ -17,6 +18,7 @@ declare module "next-auth" {
     email: string
     name?: string | null
     role?: string | null
+    imageUrl?: string | null
   }
 }
 
@@ -26,5 +28,7 @@ declare module "next-auth/jwt" {
     /** The user's id. */
     id: string
     role?: string | null
+    image?: string | null
+    imageUrl?: string | null
   }
 }


### PR DESCRIPTION
## Summary
- ensure image uploads use a standard `<img>` preview so new avatars display immediately
- propagate saved avatar URLs through the NextAuth session and navigation components so profile photos render everywhere
- load Lucide icon metadata from the exported `icons` map to restore filtering and selection in the skill forms

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_690631b1c0fc832c89e352e575dac752