### PR TITLE
Fix project creation text limits and cache behaviour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ medium-private-key.pem
 /logs
 *.log
 
-prisma/migrations/*
+# Allow committed Prisma migrations
+!prisma/migrations/
+!prisma/migrations/**
 prisma/dev.db
 prisma/dev.db-journal

--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server"
+import { revalidatePath } from "next/cache"
 import { getServerSession } from "next-auth"
 import { authOptions } from "@/lib/auth"
 import prisma from "@/lib/db"
@@ -157,6 +158,11 @@ export async function POST(req: Request) {
         features: true,
       },
     })
+
+    revalidatePath("/projects")
+    revalidatePath("/")
+    revalidatePath("/dashboard")
+    revalidatePath("/dashboard/projects")
 
     return NextResponse.json({ project })
   } catch (error) {

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -11,6 +11,8 @@ import { Card, CardContent } from "@/components/ui/card"
 import { AnimatedSection } from "@/components/animated-section"
 import { AnimatedList } from "@/components/animated-list"
 
+export const dynamic = "force-dynamic"
+
 export const metadata = {
   title: "Projects | Tim Hauke",
   description: "Explore my portfolio of web development projects",

--- a/components/featured-projects.tsx
+++ b/components/featured-projects.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link"
 import Image from "next/image"
-import { cache } from "react"
 import { ExternalLink, Github } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
@@ -17,10 +16,8 @@ import { getFeaturedProjects } from "@/lib/projects"
 // Add proper type for projects
 import type { Project } from "@/types/database"
 
-const getCachedProjects = cache(getFeaturedProjects)
-
 export async function FeaturedProjects() {
-  const projects = await getCachedProjects(3)
+  const projects = await getFeaturedProjects(3)
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">

--- a/prisma/migrations/20240711120000_increase_project_text_fields/migration.sql
+++ b/prisma/migrations/20240711120000_increase_project_text_fields/migration.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `Project`
+  MODIFY `developmentProcess` LONGTEXT NULL,
+  MODIFY `challengesFaced` LONGTEXT NULL,
+  MODIFY `futurePlans` LONGTEXT NULL,
+  MODIFY `logContent` LONGTEXT NULL;

--- a/prisma/migrations/migration_lock.toml
+++ b/prisma/migrations/migration_lock.toml
@@ -1,0 +1,1 @@
+provider = "mysql"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -41,10 +41,10 @@ model Project {
   logoUrl            String?          @db.Text
   githubUrl          String?          @db.Text
   featured           Boolean          @default(false)
-  developmentProcess String?          @db.Text
-  challengesFaced    String?          @db.Text
-  futurePlans        String?          @db.Text
-  logContent         String?          @db.Text
+  developmentProcess String?          @db.LongText
+  challengesFaced    String?          @db.LongText
+  futurePlans        String?          @db.LongText
+  logContent         String?          @db.LongText
   createdAt          DateTime         @default(now())
   updatedAt          DateTime         @updatedAt
   userId             String


### PR DESCRIPTION
## Summary
- allow Prisma project narrative fields to store very large entries and add a migration
- remove stale caching so featured projects and the projects page update immediately after creation
- trigger revalidation of key pages when projects are created and mark the projects listing page as dynamic

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_69063b135bac832cb3e0cc035438e584