### PR TITLE
Ensure project long-form fields support extended content

### DIFF
--- a/app/api/projects/[id]/route.ts
+++ b/app/api/projects/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server"
 import { revalidatePath } from "next/cache"
 import { getServerSession } from "next-auth"
+import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library"
 
 import { authOptions } from "@/lib/auth"
 import prisma from "@/lib/db"
@@ -10,6 +11,7 @@ import {
   normalizeOptionalString,
   sanitizeFeatureList,
 } from "@/lib/project-validation"
+import { ensureProjectLongFormColumns } from "@/lib/project-longform"
 
 interface RouteParams {
   params: Promise<{
@@ -110,6 +112,8 @@ export async function PUT(req: Request, { params }: RouteParams) {
     // Update project
     const sanitizedFeatureList = sanitizeFeatureList(features)
 
+    await ensureProjectLongFormColumns()
+
     const project = await prisma.project.update({
       where: {
         id: projectId,
@@ -154,6 +158,21 @@ export async function PUT(req: Request, { params }: RouteParams) {
     return NextResponse.json({ project })
   } catch (error) {
     console.error("Error updating project:", error)
+
+    if (error instanceof PrismaClientKnownRequestError && error.code === "P2000") {
+      const column = typeof error.meta?.column_name === "string" ? error.meta.column_name : "one of the fields"
+      return NextResponse.json(
+        {
+          error: `The provided value for ${column} is too long. Please reduce the content and try again.`,
+        },
+        { status: 400 },
+      )
+    }
+
+    if (error instanceof Error && error.message.includes("Failed to prepare the database")) {
+      return NextResponse.json({ error: error.message }, { status: 500 })
+    }
+
     return NextResponse.json({ error: "Something went wrong" }, { status: 500 })
   }
 }

--- a/lib/project-longform.ts
+++ b/lib/project-longform.ts
@@ -1,0 +1,81 @@
+import prisma from "./db"
+
+const PROJECT_LONGFORM_COLUMNS = [
+  "developmentProcess",
+  "challengesFaced",
+  "futurePlans",
+  "logContent",
+] as const
+
+type ProjectLongFormColumn = (typeof PROJECT_LONGFORM_COLUMNS)[number]
+
+let ensured = false
+let ensurePromise: Promise<void> | null = null
+
+function isMySqlDatabase(): boolean {
+  const url = process.env.DATABASE_URL ?? ""
+  return url.startsWith("mysql://") || url.startsWith("mysqls://")
+}
+
+async function fetchProjectColumnTypes() {
+  const result = await prisma.$queryRawUnsafe(
+    `SHOW COLUMNS FROM \`Project\` WHERE Field IN (${PROJECT_LONGFORM_COLUMNS.map((column) => `'${column}'`).join(",")})`,
+  )
+
+  return result as Array<{ Field: string; Type: string }>
+}
+
+function needsAlteration(columns: Array<{ Field: string; Type: string }>): boolean {
+  const columnTypeMap = new Map<ProjectLongFormColumn, string>()
+
+  for (const column of columns) {
+    const field = column.Field as ProjectLongFormColumn
+    if (PROJECT_LONGFORM_COLUMNS.includes(field)) {
+      columnTypeMap.set(field, column.Type.toLowerCase())
+    }
+  }
+
+  return PROJECT_LONGFORM_COLUMNS.some((column) => columnTypeMap.get(column) !== "longtext")
+}
+
+async function applyAlterations() {
+  const clauses = PROJECT_LONGFORM_COLUMNS.map((column) => `MODIFY \`${column}\` LONGTEXT NULL`).join(",\n  ")
+  await prisma.$executeRawUnsafe(`ALTER TABLE \`Project\`\n  ${clauses};`)
+}
+
+export async function ensureProjectLongFormColumns() {
+  if (ensured) {
+    return
+  }
+
+  if (!isMySqlDatabase()) {
+    ensured = true
+    return
+  }
+
+  if (!ensurePromise) {
+    ensurePromise = (async () => {
+      try {
+        const columns = await fetchProjectColumnTypes()
+        if (!Array.isArray(columns) || needsAlteration(columns)) {
+          await applyAlterations()
+        }
+        ensured = true
+        ensurePromise = null
+      } catch (error) {
+        console.error("Failed to ensure long-form project columns:", error)
+        ensurePromise = null
+        throw error
+      }
+    })()
+  }
+
+  try {
+    await ensurePromise
+  } catch (error) {
+    throw new Error(
+      "Failed to prepare the database for long-form project content. Please check database permissions and connectivity.",
+      { cause: error },
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- add a database safeguard that upgrades project long-form columns to LONGTEXT when needed
- ensure project creation and updates invoke the safeguard before writing data
- return clear validation messages when Prisma reports oversized field values

## Testing
- pnpm lint
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_690649589e28832c93bcebcfe064efe9