### PR TITLE
Fix build failures without database or font access

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,7 @@
 /* eslint-disable react-refresh/only-export-components */
 import type { Metadata, Viewport } from "next"
 import Script from "next/script"
-import { Inter } from "next/font/google"
 
-import { cn } from "@/lib/utils"
 import { getSiteUrl, siteProfile } from "@/lib/site"
 import { Providers } from "@/components/providers"
 
@@ -13,8 +11,6 @@ const metadataBase = new URL(getSiteUrl())
 
 const siteName = siteProfile.name
 const siteDescription = siteProfile.defaultDescription
-
-const inter = Inter({ subsets: ["latin"] })
 
 export const metadata: Metadata = {
   metadataBase,
@@ -187,7 +183,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={cn(inter.className, "min-h-screen bg-background text-foreground antialiased")}>
+      <body className="min-h-screen bg-background text-foreground antialiased font-sans">
         <Providers>{children}</Providers>
         <Script id="structured-data" type="application/ld+json">
           {JSON.stringify(structuredData)}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -102,15 +102,18 @@ try {
   }
 }
 
+const hasDatabaseUrl = Boolean(process.env.DATABASE_URL)
+const shouldUseStub = !PrismaClientCtor || !hasDatabaseUrl
+
 const prisma =
   globalForPrisma.prisma ||
-  (PrismaClientCtor
-    ? new PrismaClientCtor({
+  (shouldUseStub
+    ? createStubClient()
+    : new PrismaClientCtor!({
         log: process.env.NODE_ENV === "development" ? ["query", "error", "warn"] : ["error"],
-      })
-    : createStubClient())
+      }))
 
-if (PrismaClientCtor) {
+if (!shouldUseStub) {
   registerPrismaRealtime(prisma as PrismaClientType)
 }
 

--- a/types/prisma.d.ts
+++ b/types/prisma.d.ts
@@ -1,11 +1,15 @@
 declare module "@prisma/client" {
   export type Prisma = Record<string, unknown>
 
+  export type PrismaPromise<T = unknown> = Promise<T>
+
   export class PrismaClient {
     constructor(...args: unknown[])
-    $connect(): Promise<void>
-    $disconnect(): Promise<void>
+    $connect(): PrismaPromise<void>
+    $disconnect(): PrismaPromise<void>
     $use(...args: unknown[]): void
-    [key: string]: unknown
+    $on(event: string, handler: (...args: unknown[]) => void): void
+    $transaction(...args: any[]): Promise<any>
+    [key: string]: any
   }
 }


### PR DESCRIPTION
## Summary
- remove the external Inter font so the build no longer fetches Google Fonts
- fall back to a stub Prisma client when DATABASE_URL is missing to avoid runtime errors during static generation

## Testing
- `npm run build`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690df6d97c04832cab29d32fbafbc272)