### PR TITLE
Fix stale dashboard updates by disabling data caching

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -49,6 +49,8 @@ export const metadata: Metadata = {
   },
 }
 
+export const revalidate = 0
+
 export default async function Home() {
   const engagementHighlights = await getEngagementHighlights()
   const heroStats = [

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -24,6 +24,8 @@ interface ProjectPageProps {
   }>
 }
 
+export const revalidate = 0
+
 export async function generateMetadata({ params }: ProjectPageProps) {
   const { id } = await params
   if (!id) {

--- a/components/certificates-showcase.tsx
+++ b/components/certificates-showcase.tsx
@@ -1,4 +1,4 @@
-import { Suspense, cache } from "react"
+import { Suspense } from "react"
 import Link from "next/link"
 import { ExternalLink, GraduationCap } from "lucide-react"
 
@@ -15,10 +15,8 @@ import { getAllCertificates } from "@/lib/certificates"
 import { CertificatesShowcaseSkeleton } from "@/components/skeletons/certificates-showcase-skeleton"
 import type { Certificate } from "@/types/database"
 
-const getCachedCertificates = cache(getAllCertificates)
-
 async function CertificatesShowcaseContent() {
-  const certificates = await getCachedCertificates(3)
+  const certificates = await getAllCertificates(3)
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">

--- a/components/skills-showcase.tsx
+++ b/components/skills-showcase.tsx
@@ -1,5 +1,5 @@
 import type React from "react"
-import { Suspense, cache } from "react"
+import { Suspense } from "react"
 import { Code2, Database, Server, Globe, Cpu, Layers } from "lucide-react"
 import * as LucideIcons from "lucide-react"
 import { getAllSkills } from "@/lib/skills"
@@ -21,10 +21,8 @@ const categoryIcons: Record<string, LucideIconType> = {
   Other: Layers,
 }
 
-const getCachedSkills = cache(getAllSkills)
-
 async function SkillsContent() {
-  const skills = await getCachedSkills()
+  const skills = await getAllSkills()
 
   // Group skills by category
   const groupedSkills: Record<string, Skill[]> = {}

--- a/lib/certificates.ts
+++ b/lib/certificates.ts
@@ -1,7 +1,10 @@
+import { unstable_noStore as noStore } from "next/cache"
+
 import prisma from "@/lib/db"
 import type { Certificate } from "@/types/database"
 
 export async function getAllCertificates(limit?: number): Promise<Certificate[]> {
+  noStore()
   try {
     // Get the first user (assuming it's the portfolio owner)
     const user = await prisma.user.findFirst()
@@ -34,6 +37,7 @@ export async function getAllCertificates(limit?: number): Promise<Certificate[]>
 }
 
 export async function getCertificateById(id: string): Promise<Certificate | null> {
+  noStore()
   try {
     const certificate = await prisma.certificate.findUnique({
       where: {

--- a/lib/engagement.ts
+++ b/lib/engagement.ts
@@ -1,3 +1,5 @@
+import { unstable_noStore as noStore } from "next/cache"
+
 import prisma from "@/lib/db"
 import type {
   EngagementHighlightProject,
@@ -42,6 +44,7 @@ type RawProjectHighlight = {
 }
 
 export async function getProjectComments(projectId: string): Promise<ProjectComment[]> {
+  noStore()
   try {
     const comments = (await prisma.projectComment.findMany({
       where: { projectId },
@@ -80,6 +83,7 @@ export async function getProjectComments(projectId: string): Promise<ProjectComm
 }
 
 export async function getProjectReactionSummary(projectId: string): Promise<ReactionSummary> {
+  noStore()
   try {
     const counts = (await prisma.projectReaction.groupBy({
       by: ["type"],
@@ -120,6 +124,7 @@ export async function getProjectReactionSummary(projectId: string): Promise<Reac
 }
 
 export async function getEngagementHighlights(limit = 3): Promise<EngagementHighlights> {
+  noStore()
   try {
     const [totalComments, totalReactions, memberCount, topProjectsRaw, latestCommentRaw] =
       await Promise.all([

--- a/lib/projects.ts
+++ b/lib/projects.ts
@@ -1,7 +1,10 @@
+import { unstable_noStore as noStore } from "next/cache"
+
 import prisma from "@/lib/db"
 import type { Project } from "@/types/database"
 
 export async function getProjects() {
+  noStore()
   try {
     if (!prisma) {
       console.error("Prisma client is not initialized")
@@ -22,6 +25,7 @@ export async function getProjects() {
 }
 
 export async function getAllProjects(): Promise<Project[]> {
+  noStore()
   try {
     if (!prisma) {
       console.error("Prisma client is not initialized")
@@ -45,6 +49,7 @@ export async function getAllProjects(): Promise<Project[]> {
 }
 
 export async function getProjectById(id: string): Promise<Project | null> {
+  noStore()
   try {
     if (!prisma) {
       console.error("Prisma client is not initialized")
@@ -68,6 +73,7 @@ export async function getProjectById(id: string): Promise<Project | null> {
 }
 
 export async function getFeaturedProjects(limit = 3): Promise<Project[]> {
+  noStore()
   try {
     if (!prisma) {
       console.error("Prisma client is not initialized")

--- a/lib/skills.ts
+++ b/lib/skills.ts
@@ -1,7 +1,10 @@
+import { unstable_noStore as noStore } from "next/cache"
+
 import prisma from "@/lib/db"
 import type { Skill } from "@/types/database"
 
 export async function getAllSkills(): Promise<Skill[]> {
+  noStore()
   try {
     const skills = await prisma.skill.findMany({
       orderBy: [{ category: "asc" }, { level: "desc" }, { name: "asc" }],
@@ -15,6 +18,7 @@ export async function getAllSkills(): Promise<Skill[]> {
 }
 
 export async function getSkillById(id: string): Promise<Skill | null> {
+  noStore()
   try {
     const skill = await prisma.skill.findUnique({
       where: {
@@ -30,6 +34,7 @@ export async function getSkillById(id: string): Promise<Skill | null> {
 }
 
 export async function getSkillsByCategory(category: string): Promise<Skill[]> {
+  noStore()
   try {
     // Get the first user (assuming it's the portfolio owner)
     const user = await prisma.user.findFirst()


### PR DESCRIPTION
## Summary
- disable Next.js caching for portfolio data queries so dashboard edits appear immediately
- remove component-level caching around skills and certificates showcases to refetch latest content
- force dynamic rendering for key public pages that display dashboard-managed data

## Testing
- pnpm lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e0112aecc832c833f35b0b1639438)